### PR TITLE
Bug/49 dictionary pagination

### DIFF
--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -15,7 +15,7 @@ module.exports = {
       options: {
         path: "content/dictionary/**/*.md",
         typeName: "Dictionarypost",
-        route: "dictionary/:title",
+        route: "dictionary/entry/:title",
         remark: {
           // remark options
           plugins: [

--- a/src/pages/Dictionary.vue
+++ b/src/pages/Dictionary.vue
@@ -10,7 +10,7 @@
     <div
       v-for="post in $page.dictionaryposts.edges"
       :key="post.id"
-      class="border-purple-900 border-t py-2"
+      class="py-2 border-t border-purple-900"
     >
       <g-link :to="post.node.path" class="font-bold">{{
         post.node.title
@@ -28,7 +28,7 @@
     <!-- Pagination -->
     <PaginationDictionaryposts
       v-if="$page.dictionaryposts.pageInfo.totalPages > 1"
-      base="/blog"
+      base="/dictionary"
       :totalPages="$page.dictionaryposts.pageInfo.totalPages"
       :currentPage="$page.dictionaryposts.pageInfo.currentPage"
     />


### PR DESCRIPTION
**Issues fixed**
This PR fixes #49.

**Work done**
- Updated the base to `/dictionary` instead of `/blog` (doh!)
- Nested dictionary entries as `/dictionary/entry/someEntry` to easily handle numerical titles such as "42." 😄 

**Testing instructions**
- On `/dictionary`, use the "next" and "prev" buttons to to through the pages of entries. Pages should show correctly.
- Navigate to `/dictionary/entry/42/`. See that it loads correctly.