### PR TITLE
Added definition of 42 from Hitchhiker's Guide

### DIFF
--- a/content/dictionary/42.md
+++ b/content/dictionary/42.md
@@ -2,8 +2,8 @@
 title: "42"
 definition: ''
 sources:
-- https://hitchhikers.fandom.com/wiki/42
-
+- sourceurl: https://hitchhikers.fandom.com/wiki/42
 perspectives:
-- meaning: The answer to the Ultimate Question of Life, The Universe and Everything according to the supercomputer Deep Thought. The answer was generated after seven and a half million years of computation.
+- meaning: The answer to the Ultimate Question of Life, The Universe and Everything.
+  role: Deep Thought Supercomputer
 ---

--- a/content/dictionary/42.md
+++ b/content/dictionary/42.md
@@ -1,6 +1,9 @@
 ---
 title: "42"
 definition: ''
-perspectives: []
+sources:
+- https://hitchhikers.fandom.com/wiki/42
 
+perspectives:
+- meaning: The answer to the Ultimate Question of Life, The Universe and Everything according to the supercomputer Deep Thought. The answer was generated after seven and a half million years of computation.
 ---


### PR DESCRIPTION
## This PR fixes...
This pull request does not fix an issue. It is exclusively or the addition of content

## What I did...
- The pull request added the definition of "42" according to The Hitchhiker's Guide to the Galaxy.

## How to test...

_In a list format, tell us how to test this PR._
Ex:

1. Navigate to https://hitchhikers.fandom.com/wiki/42
2. Compare the description of "42" on the webpage to the definition of "42" in this pull request
3. See that the definition in the pull request gives a brief and informative idea of what "42" means in the context of the given page.

## I learned...

There are a number of perspectives that may be added to "42", including the relationship between it and the asterisk.