### PR TITLE
Feat/dict filtering

### DIFF
--- a/src/components/controls/base/BaseInput.vue
+++ b/src/components/controls/base/BaseInput.vue
@@ -1,0 +1,28 @@
+<template>
+  <div>
+    <label for="baseInput" v-if="label">
+      {{ label }}
+    </label>
+    <input
+      :value="value"
+      @input="$emit('input', $event.target.value)"
+      id="baseInput"
+      type="text"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    value: {
+      type: String,
+      default: "",
+    },
+    label: {
+      type: String,
+      default: "",
+    },
+  },
+};
+</script>

--- a/src/pages/Dictionary.vue
+++ b/src/pages/Dictionary.vue
@@ -87,7 +87,6 @@ export default {
     return {
       search: "",
       entries: [],
-      dictSearchTerm: "",
     };
   },
   created() {

--- a/src/pages/Dictionary.vue
+++ b/src/pages/Dictionary.vue
@@ -11,14 +11,16 @@
     <p class="mb-6">
       Choose a word below that needs a definition or a perspective. Then read
       our
-      <a href="https://github.com/cherryontech/website/blob/pit/CONTRIBUTING.md"
+      <a
+        class="underline"
+        href="https://github.com/cherryontech/website/blob/pit/CONTRIBUTING.md"
         >Contributing HowTo</a
       >
       to get started!
     </p>
-
+    <BaseInput v-model="search" label="Search the dictionary: " />
     <div
-      v-for="post in entries"
+      v-for="post in filteredTerms"
       :key="post.id"
       class="py-2 border-t border-purple-900"
     >
@@ -73,17 +75,30 @@ query Dictionaryposts {
 </page-query>
 
 <script>
+import BaseInput from "@/components/controls/base/BaseInput.vue";
 export default {
+  components: {
+    BaseInput,
+  },
   metaInfo: {
     title: "Dictionary",
   },
   data() {
     return {
+      search: "",
       entries: [],
+      dictSearchTerm: "",
     };
   },
   created() {
     this.entries = this.sortEntries(this.$page.dictionaryposts.edges);
+  },
+  computed: {
+    filteredTerms() {
+      return this.entries.filter((entry) => {
+        return entry.node.title.toLowerCase().match(this.search.toLowerCase());
+      });
+    },
   },
   methods: {
     sortEntries(allentries) {


### PR DESCRIPTION
## This PR fixes...

This PR follows up on #79 and #80 - now that we have all the dictionary terms on one page, we need a way for users to quickly sort them.

## What I did...

- Made a `BaseInput` component
- Used the new component and created a computed property to filter all the dictionary entries by the term searched.

## How to test...

1. Navigate to /dictionary
1. In the search box, begin typing a word, such as "developer" (no quotes). You should see the list begin to filter down to only the terms which contain the letters you searched.

## I learned...

I learned more about using v-model: https://vuejs.org/v2/guide/components.html#Using-v-model-on-Components
