### PR TITLE
Remove the 'replace with your text' placeholder

### DIFF
--- a/.forestry/front_matter/templates/dictionary-entry.yml
+++ b/.forestry/front_matter/templates/dictionary-entry.yml
@@ -2,331 +2,334 @@
 label: Dictionary entry
 hide_body: true
 fields:
-- name: title
-  type: text
-  config:
-    required: true
-  label: Word/phrase to be defined
-  default: replaceme
-- name: definition
-  type: text
-  config:
-    required: false
-  label: Definition
-  description: If you believe there is <em>one</em> definition which readily explains
-    this word, add it here.
-  default: replace with with your own definition
-- name: sources
-  type: field_group_list
-  fields:
-  - name: sourceurl
+  - name: title
+    type: text
+    config:
+      required: true
+    label: Word/phrase to be defined
+    default: replaceme
+  - name: definition
     type: text
     config:
       required: false
-    label: Link to source
-    description: Add a citation if you have quoted anyone.
-    default: replace with with your own source link
-  config:
-    min: 
-    max: 
-    labelField: 
-  label: Sources
-- name: perspectives
-  type: field_group_list
-  fields:
-  - name: meaning
-    type: text
+    label: Definition
+    description:
+      If you believe there is <em>one</em> definition which readily explains
+      this word, add it here.
+    default:
+  - name: sources
+    type: field_group_list
+    fields:
+      - name: sourceurl
+        type: text
+        config:
+          required: false
+        label: Link to source
+        description: Add a citation if you have quoted anyone.
+        default: replace with with your own source link
     config:
-      required: false
-    label: Meaning
-    description: This should be the &lt;meaning&gt; in the sentence, "As a &lt;role&gt;,
-      &lt;term&gt; means &lt;meaning&gt;."
-    default: replace with with your own meaning
-  - name: role
-    type: text
+      min:
+      max:
+      labelField:
+    label: Sources
+  - name: perspectives
+    type: field_group_list
+    fields:
+      - name: meaning
+        type: text
+        config:
+          required: false
+        label: Meaning
+        description:
+          This should be the &lt;meaning&gt; in the sentence, "As a &lt;role&gt;,
+          &lt;term&gt; means &lt;meaning&gt;."
+        default: replace with with your own meaning
+      - name: role
+        type: text
+        config:
+          required: false
+        label: Role
+        description:
+          This is the &lt;role&gt; in the sentence, "As a &lt;role&gt;, &lt;term&gt;
+          means &lt;meaning&gt;."
+        default: replace with with your own role
     config:
-      required: false
-    label: Role
-    description: This is the &lt;role&gt; in the sentence, "As a &lt;role&gt;, &lt;term&gt;
-      means &lt;meaning&gt;."
-    default: replace with with your own role
-  config:
-    min: 
-    max: 
-    labelField: role
-  label: Perspectives
+      min:
+      max:
+      labelField: role
+    label: Perspectives
 pages:
-- content/dictionary/.net.md
-- content/dictionary/1-on-1.md
-- content/dictionary/1.md
-- content/dictionary/10x-developer.md
-- content/dictionary/3-click-rule.md
-- content/dictionary/32-bit.md
-- content/dictionary/42.md
-- content/dictionary/5-planes.md
-- content/dictionary/60-30-10-rule.md
-- content/dictionary/64-bit.md
-- content/dictionary/80-20-rule.md
-- content/dictionary/a-b-testing.md
-- content/dictionary/accessibility-a11y.md
-- content/dictionary/adaptive.md
-- content/dictionary/aesthetic.md
-- content/dictionary/affordance.md
-- content/dictionary/agile.md
-- content/dictionary/alfred.md
-- content/dictionary/analytics.md
-- content/dictionary/android.md
-- content/dictionary/angular.md
-- content/dictionary/api.md
-- content/dictionary/app.md
-- content/dictionary/application-programming-interface-api.md
-- content/dictionary/argument.md
-- content/dictionary/artificial-intelligence-ai.md
-- content/dictionary/ascii-art.md
-- content/dictionary/ascii.md
-- content/dictionary/atomic-design.md
-- content/dictionary/automated-testing.md
-- content/dictionary/automation.md
-- content/dictionary/avatar.md
-- content/dictionary/backlog.md
-- content/dictionary/bar.md
-- content/dictionary/baz.md
-- content/dictionary/behavior-driven-development.md
-- content/dictionary/bitmap.md
-- content/dictionary/blog.md
-- content/dictionary/branch.md
-- content/dictionary/branching.md
-- content/dictionary/brand-book.md
-- content/dictionary/breadcrumb.md
-- content/dictionary/bug.md
-- content/dictionary/burnout.md
-- content/dictionary/c-level.md
-- content/dictionary/c.md
-- content/dictionary/cache.md
-- content/dictionary/call-to-action-cta.md
-- content/dictionary/callback-hell.md
-- content/dictionary/card-sorting.md
-- content/dictionary/cascading-style-sheets-css.md
-- content/dictionary/case-study.md
-- content/dictionary/catalina.md
-- content/dictionary/chatbot.md
-- content/dictionary/chief-executive-officer-ceo.md
-- content/dictionary/chief-operations-officer-ceo.md
-- content/dictionary/chief-technical-officer-cto.md
-- content/dictionary/ci-cd.md
-- content/dictionary/class.md
-- content/dictionary/clickstream.md
-- content/dictionary/color-contrast.md
-- content/dictionary/color-wheel.md
-- content/dictionary/command-line-application-cli.md
-- content/dictionary/commit-history.md
-- content/dictionary/commit.md
-- content/dictionary/consistency.md
-- content/dictionary/context-of-use-analysis.md
-- content/dictionary/contribute.md
-- content/dictionary/conversion-rate-1.md
-- content/dictionary/conversion-rate.md
-- content/dictionary/corporate-identity-guideline.md
-- content/dictionary/crazy-8s.md
-- content/dictionary/crm.md
-- content/dictionary/css.md
-- content/dictionary/customer-experience-cx.md
-- content/dictionary/customer-journey-map-cjm.md
-- content/dictionary/data-science.md
-- content/dictionary/data-sets.md
-- content/dictionary/database.md
-- content/dictionary/design-debt.md
-- content/dictionary/design-thinking.md
-- content/dictionary/desktop.md
-- content/dictionary/developer.md
-- content/dictionary/devops.md
-- content/dictionary/devsecops.md
-- content/dictionary/diary-study.md
-- content/dictionary/div.md
-- content/dictionary/diversity-and-inclusion-d-i.md
-- content/dictionary/diversity-equity-and-inclusion-dei.md
-- content/dictionary/divitis.md
-- content/dictionary/dots-per-inch-dpi.md
-- content/dictionary/drop-dead-date.md
-- content/dictionary/edge-case.md
-- content/dictionary/em.md
-- content/dictionary/empathy-map.md
-- content/dictionary/end-to-end-test-e2e.md
-- content/dictionary/end-user.md
-- content/dictionary/end-users.md
-- content/dictionary/engineering-manager.md
-- content/dictionary/error-prevention.md
-- content/dictionary/example-phrase.md
-- content/dictionary/eye-tracking.md
-- content/dictionary/f-shaped-pattern.md
-- content/dictionary/feature-branch.md
-- content/dictionary/feature.md
-- content/dictionary/fishbone-diagram.md
-- content/dictionary/fitts-law.md
-- content/dictionary/flat-design.md
-- content/dictionary/flowchart.md
-- content/dictionary/fontface.md
-- content/dictionary/foo.md
-- content/dictionary/footer.md
-- content/dictionary/gamification.md
-- content/dictionary/general-data-protection-regulation-gdpr.md
-- content/dictionary/gestalt-principles.md
-- content/dictionary/git.md
-- content/dictionary/github.md
-- content/dictionary/gitlab.md
-- content/dictionary/go-live.md
-- content/dictionary/golden-ratio.md
-- content/dictionary/grandboss.md
-- content/dictionary/graphical-user-interface-gui.md
-- content/dictionary/grid-system.md
-- content/dictionary/grid.md
-- content/dictionary/happy-path.md
-- content/dictionary/hardware.md
-- content/dictionary/head.md
-- content/dictionary/header.md
-- content/dictionary/heat-map.md
-- content/dictionary/heat-maps.md
-- content/dictionary/hero-page.md
-- content/dictionary/heuristic-evaluation.md
-- content/dictionary/homepage.md
-- content/dictionary/human-computer-interaction.md
-- content/dictionary/hybrid-app.md
-- content/dictionary/hypertext-markup-language-html.md
-- content/dictionary/ideation.md
-- content/dictionary/information-architecture.md
-- content/dictionary/integration-test.md
-- content/dictionary/interaction-design.md
-- content/dictionary/internationalization-i18n.md
-- content/dictionary/ios.md
-- content/dictionary/ip-address.md
-- content/dictionary/issue.md
-- content/dictionary/it-works-on-my-machine.md
-- content/dictionary/iteration.md
-- content/dictionary/jamstack.md
-- content/dictionary/java.md
-- content/dictionary/javascript.md
-- content/dictionary/jenkins.md
-- content/dictionary/jira.md
-- content/dictionary/junior.md
-- content/dictionary/kpi.md
-- content/dictionary/landing-page-1.md
-- content/dictionary/landing-page.md
-- content/dictionary/lean-ux.md
-- content/dictionary/leaner-style-sheets-less.md
-- content/dictionary/level-of-effort-loe.md
-- content/dictionary/linux.md
-- content/dictionary/mac.md
-- content/dictionary/machine-learning-ml.md
-- content/dictionary/manual-qa.md
-- content/dictionary/markup.md
-- content/dictionary/material-design.md
-- content/dictionary/mental-model.md
-- content/dictionary/mentorship.md
-- content/dictionary/microcopy.md
-- content/dictionary/microservices.md
-- content/dictionary/midlevel.md
-- content/dictionary/migration.md
-- content/dictionary/mindmap.md
-- content/dictionary/mobile-development.md
-- content/dictionary/mobile-web.md
-- content/dictionary/mockup.md
-- content/dictionary/mvp.md
-- content/dictionary/n-1.md
-- content/dictionary/nav.md
-- content/dictionary/navigation.md
-- content/dictionary/nix.md
-- content/dictionary/nth.md
-- content/dictionary/numeronym.md
-- content/dictionary/onboarding.md
-- content/dictionary/open-source-software-oss.md
-- content/dictionary/pairing-development-pairing-programming.md
-- content/dictionary/persona.md
-- content/dictionary/personal-computer-pc.md
-- content/dictionary/personal-improvement-plan-pip.md
-- content/dictionary/picture-in-picture-pip.md
-- content/dictionary/pixel.md
-- content/dictionary/png.md
-- content/dictionary/prod.md
-- content/dictionary/product-manager-pm.md
-- content/dictionary/project-manager-pm.md
-- content/dictionary/prototype.md
-- content/dictionary/pull-request-pr.md
-- content/dictionary/quality-assurance-qa.md
-- content/dictionary/random-access-memory-ram.md
-- content/dictionary/raster-graphics.md
-- content/dictionary/raw.md
-- content/dictionary/react.md
-- content/dictionary/refactoring.md
-- content/dictionary/rem.md
-- content/dictionary/replaceme.md
-- content/dictionary/repository.md
-- content/dictionary/responsive.md
-- content/dictionary/ruby-on-rails.md
-- content/dictionary/ruby.md
-- content/dictionary/saas.md
-- content/dictionary/sassy-css-scss.md
-- content/dictionary/scalable-vector-graphic-svg.md
-- content/dictionary/scrum.md
-- content/dictionary/sdk.md
-- content/dictionary/search-engine-optimization-seo.md
-- content/dictionary/search-engine.md
-- content/dictionary/select.md
-- content/dictionary/semantic-html.md
-- content/dictionary/senior.md
-- content/dictionary/seo.md
-- content/dictionary/site-map.md
-- content/dictionary/sketching.md
-- content/dictionary/skip-level.md
-- content/dictionary/slack.md
-- content/dictionary/software-as-a-service-saas.md
-- content/dictionary/software-engineer-swe.md
-- content/dictionary/splash-page.md
-- content/dictionary/sponsorship.md
-- content/dictionary/sprints.md
-- content/dictionary/staging.md
-- content/dictionary/sticker-driven-developer.md
-- content/dictionary/story-points.md
-- content/dictionary/storyboard.md
-- content/dictionary/storybook.md
-- content/dictionary/stream.md
-- content/dictionary/svg.md
-- content/dictionary/syntactically-awesome-style-sheets-sass.md
-- content/dictionary/task-analysis.md
-- content/dictionary/tech-squad.md
-- content/dictionary/technical-debt-1.md
-- content/dictionary/technical-debt.md
-- content/dictionary/technical-lead.md
-- content/dictionary/technical-writer.md
-- content/dictionary/test-case.md
-- content/dictionary/test-driven-development-tdd.md
-- content/dictionary/tl-dr.md
-- content/dictionary/trello-board.md
-- content/dictionary/turing-complete.md
-- content/dictionary/ubuntu.md
-- content/dictionary/ui-element.md
-- content/dictionary/ui-pattern.md
-- content/dictionary/unit-test.md
-- content/dictionary/unit-testing.md
-- content/dictionary/unix.md
-- content/dictionary/usability-testing.md
-- content/dictionary/user-centered-design.md
-- content/dictionary/user-engagement.md
-- content/dictionary/user-experience-ux.md
-- content/dictionary/user-flow.md
-- content/dictionary/user-interface.md
-- content/dictionary/user-journey-maps.md
-- content/dictionary/user-research.md
-- content/dictionary/user-scenario.md
-- content/dictionary/user-stories.md
-- content/dictionary/vector.md
-- content/dictionary/version-control-system-vcs.md
-- content/dictionary/vertical-rhythm.md
-- content/dictionary/visibility-of-system-status.md
-- content/dictionary/vlog.md
-- content/dictionary/vue.md
-- content/dictionary/waterfall-1.md
-- content/dictionary/waterfall.md
-- content/dictionary/webpack.md
-- content/dictionary/white-space.md
-- content/dictionary/whiteboard-interview.md
-- content/dictionary/wireframe.md
+  - content/dictionary/.net.md
+  - content/dictionary/1-on-1.md
+  - content/dictionary/1.md
+  - content/dictionary/10x-developer.md
+  - content/dictionary/3-click-rule.md
+  - content/dictionary/32-bit.md
+  - content/dictionary/42.md
+  - content/dictionary/5-planes.md
+  - content/dictionary/60-30-10-rule.md
+  - content/dictionary/64-bit.md
+  - content/dictionary/80-20-rule.md
+  - content/dictionary/a-b-testing.md
+  - content/dictionary/accessibility-a11y.md
+  - content/dictionary/adaptive.md
+  - content/dictionary/aesthetic.md
+  - content/dictionary/affordance.md
+  - content/dictionary/agile.md
+  - content/dictionary/alfred.md
+  - content/dictionary/analytics.md
+  - content/dictionary/android.md
+  - content/dictionary/angular.md
+  - content/dictionary/api.md
+  - content/dictionary/app.md
+  - content/dictionary/application-programming-interface-api.md
+  - content/dictionary/argument.md
+  - content/dictionary/artificial-intelligence-ai.md
+  - content/dictionary/ascii-art.md
+  - content/dictionary/ascii.md
+  - content/dictionary/atomic-design.md
+  - content/dictionary/automated-testing.md
+  - content/dictionary/automation.md
+  - content/dictionary/avatar.md
+  - content/dictionary/backlog.md
+  - content/dictionary/bar.md
+  - content/dictionary/baz.md
+  - content/dictionary/behavior-driven-development.md
+  - content/dictionary/bitmap.md
+  - content/dictionary/blog.md
+  - content/dictionary/branch.md
+  - content/dictionary/branching.md
+  - content/dictionary/brand-book.md
+  - content/dictionary/breadcrumb.md
+  - content/dictionary/bug.md
+  - content/dictionary/burnout.md
+  - content/dictionary/c-level.md
+  - content/dictionary/c.md
+  - content/dictionary/cache.md
+  - content/dictionary/call-to-action-cta.md
+  - content/dictionary/callback-hell.md
+  - content/dictionary/card-sorting.md
+  - content/dictionary/cascading-style-sheets-css.md
+  - content/dictionary/case-study.md
+  - content/dictionary/catalina.md
+  - content/dictionary/chatbot.md
+  - content/dictionary/chief-executive-officer-ceo.md
+  - content/dictionary/chief-operations-officer-ceo.md
+  - content/dictionary/chief-technical-officer-cto.md
+  - content/dictionary/ci-cd.md
+  - content/dictionary/class.md
+  - content/dictionary/clickstream.md
+  - content/dictionary/color-contrast.md
+  - content/dictionary/color-wheel.md
+  - content/dictionary/command-line-application-cli.md
+  - content/dictionary/commit-history.md
+  - content/dictionary/commit.md
+  - content/dictionary/consistency.md
+  - content/dictionary/context-of-use-analysis.md
+  - content/dictionary/contribute.md
+  - content/dictionary/conversion-rate-1.md
+  - content/dictionary/conversion-rate.md
+  - content/dictionary/corporate-identity-guideline.md
+  - content/dictionary/crazy-8s.md
+  - content/dictionary/crm.md
+  - content/dictionary/css.md
+  - content/dictionary/customer-experience-cx.md
+  - content/dictionary/customer-journey-map-cjm.md
+  - content/dictionary/data-science.md
+  - content/dictionary/data-sets.md
+  - content/dictionary/database.md
+  - content/dictionary/design-debt.md
+  - content/dictionary/design-thinking.md
+  - content/dictionary/desktop.md
+  - content/dictionary/developer.md
+  - content/dictionary/devops.md
+  - content/dictionary/devsecops.md
+  - content/dictionary/diary-study.md
+  - content/dictionary/div.md
+  - content/dictionary/diversity-and-inclusion-d-i.md
+  - content/dictionary/diversity-equity-and-inclusion-dei.md
+  - content/dictionary/divitis.md
+  - content/dictionary/dots-per-inch-dpi.md
+  - content/dictionary/drop-dead-date.md
+  - content/dictionary/edge-case.md
+  - content/dictionary/em.md
+  - content/dictionary/empathy-map.md
+  - content/dictionary/end-to-end-test-e2e.md
+  - content/dictionary/end-user.md
+  - content/dictionary/end-users.md
+  - content/dictionary/engineering-manager.md
+  - content/dictionary/error-prevention.md
+  - content/dictionary/example-phrase.md
+  - content/dictionary/eye-tracking.md
+  - content/dictionary/f-shaped-pattern.md
+  - content/dictionary/feature-branch.md
+  - content/dictionary/feature.md
+  - content/dictionary/fishbone-diagram.md
+  - content/dictionary/fitts-law.md
+  - content/dictionary/flat-design.md
+  - content/dictionary/flowchart.md
+  - content/dictionary/fontface.md
+  - content/dictionary/foo.md
+  - content/dictionary/footer.md
+  - content/dictionary/gamification.md
+  - content/dictionary/general-data-protection-regulation-gdpr.md
+  - content/dictionary/gestalt-principles.md
+  - content/dictionary/git.md
+  - content/dictionary/github.md
+  - content/dictionary/gitlab.md
+  - content/dictionary/go-live.md
+  - content/dictionary/golden-ratio.md
+  - content/dictionary/grandboss.md
+  - content/dictionary/graphical-user-interface-gui.md
+  - content/dictionary/grid-system.md
+  - content/dictionary/grid.md
+  - content/dictionary/happy-path.md
+  - content/dictionary/hardware.md
+  - content/dictionary/head.md
+  - content/dictionary/header.md
+  - content/dictionary/heat-map.md
+  - content/dictionary/heat-maps.md
+  - content/dictionary/hero-page.md
+  - content/dictionary/heuristic-evaluation.md
+  - content/dictionary/homepage.md
+  - content/dictionary/human-computer-interaction.md
+  - content/dictionary/hybrid-app.md
+  - content/dictionary/hypertext-markup-language-html.md
+  - content/dictionary/ideation.md
+  - content/dictionary/information-architecture.md
+  - content/dictionary/integration-test.md
+  - content/dictionary/interaction-design.md
+  - content/dictionary/internationalization-i18n.md
+  - content/dictionary/ios.md
+  - content/dictionary/ip-address.md
+  - content/dictionary/issue.md
+  - content/dictionary/it-works-on-my-machine.md
+  - content/dictionary/iteration.md
+  - content/dictionary/jamstack.md
+  - content/dictionary/java.md
+  - content/dictionary/javascript.md
+  - content/dictionary/jenkins.md
+  - content/dictionary/jira.md
+  - content/dictionary/junior.md
+  - content/dictionary/kpi.md
+  - content/dictionary/landing-page-1.md
+  - content/dictionary/landing-page.md
+  - content/dictionary/lean-ux.md
+  - content/dictionary/leaner-style-sheets-less.md
+  - content/dictionary/level-of-effort-loe.md
+  - content/dictionary/linux.md
+  - content/dictionary/mac.md
+  - content/dictionary/machine-learning-ml.md
+  - content/dictionary/manual-qa.md
+  - content/dictionary/markup.md
+  - content/dictionary/material-design.md
+  - content/dictionary/mental-model.md
+  - content/dictionary/mentorship.md
+  - content/dictionary/microcopy.md
+  - content/dictionary/microservices.md
+  - content/dictionary/midlevel.md
+  - content/dictionary/migration.md
+  - content/dictionary/mindmap.md
+  - content/dictionary/mobile-development.md
+  - content/dictionary/mobile-web.md
+  - content/dictionary/mockup.md
+  - content/dictionary/mvp.md
+  - content/dictionary/n-1.md
+  - content/dictionary/nav.md
+  - content/dictionary/navigation.md
+  - content/dictionary/nix.md
+  - content/dictionary/nth.md
+  - content/dictionary/numeronym.md
+  - content/dictionary/onboarding.md
+  - content/dictionary/open-source-software-oss.md
+  - content/dictionary/pairing-development-pairing-programming.md
+  - content/dictionary/persona.md
+  - content/dictionary/personal-computer-pc.md
+  - content/dictionary/personal-improvement-plan-pip.md
+  - content/dictionary/picture-in-picture-pip.md
+  - content/dictionary/pixel.md
+  - content/dictionary/png.md
+  - content/dictionary/prod.md
+  - content/dictionary/product-manager-pm.md
+  - content/dictionary/project-manager-pm.md
+  - content/dictionary/prototype.md
+  - content/dictionary/pull-request-pr.md
+  - content/dictionary/quality-assurance-qa.md
+  - content/dictionary/random-access-memory-ram.md
+  - content/dictionary/raster-graphics.md
+  - content/dictionary/raw.md
+  - content/dictionary/react.md
+  - content/dictionary/refactoring.md
+  - content/dictionary/rem.md
+  - content/dictionary/replaceme.md
+  - content/dictionary/repository.md
+  - content/dictionary/responsive.md
+  - content/dictionary/ruby-on-rails.md
+  - content/dictionary/ruby.md
+  - content/dictionary/saas.md
+  - content/dictionary/sassy-css-scss.md
+  - content/dictionary/scalable-vector-graphic-svg.md
+  - content/dictionary/scrum.md
+  - content/dictionary/sdk.md
+  - content/dictionary/search-engine-optimization-seo.md
+  - content/dictionary/search-engine.md
+  - content/dictionary/select.md
+  - content/dictionary/semantic-html.md
+  - content/dictionary/senior.md
+  - content/dictionary/seo.md
+  - content/dictionary/site-map.md
+  - content/dictionary/sketching.md
+  - content/dictionary/skip-level.md
+  - content/dictionary/slack.md
+  - content/dictionary/software-as-a-service-saas.md
+  - content/dictionary/software-engineer-swe.md
+  - content/dictionary/splash-page.md
+  - content/dictionary/sponsorship.md
+  - content/dictionary/sprints.md
+  - content/dictionary/staging.md
+  - content/dictionary/sticker-driven-developer.md
+  - content/dictionary/story-points.md
+  - content/dictionary/storyboard.md
+  - content/dictionary/storybook.md
+  - content/dictionary/stream.md
+  - content/dictionary/svg.md
+  - content/dictionary/syntactically-awesome-style-sheets-sass.md
+  - content/dictionary/task-analysis.md
+  - content/dictionary/tech-squad.md
+  - content/dictionary/technical-debt-1.md
+  - content/dictionary/technical-debt.md
+  - content/dictionary/technical-lead.md
+  - content/dictionary/technical-writer.md
+  - content/dictionary/test-case.md
+  - content/dictionary/test-driven-development-tdd.md
+  - content/dictionary/tl-dr.md
+  - content/dictionary/trello-board.md
+  - content/dictionary/turing-complete.md
+  - content/dictionary/ubuntu.md
+  - content/dictionary/ui-element.md
+  - content/dictionary/ui-pattern.md
+  - content/dictionary/unit-test.md
+  - content/dictionary/unit-testing.md
+  - content/dictionary/unix.md
+  - content/dictionary/usability-testing.md
+  - content/dictionary/user-centered-design.md
+  - content/dictionary/user-engagement.md
+  - content/dictionary/user-experience-ux.md
+  - content/dictionary/user-flow.md
+  - content/dictionary/user-interface.md
+  - content/dictionary/user-journey-maps.md
+  - content/dictionary/user-research.md
+  - content/dictionary/user-scenario.md
+  - content/dictionary/user-stories.md
+  - content/dictionary/vector.md
+  - content/dictionary/version-control-system-vcs.md
+  - content/dictionary/vertical-rhythm.md
+  - content/dictionary/visibility-of-system-status.md
+  - content/dictionary/vlog.md
+  - content/dictionary/vue.md
+  - content/dictionary/waterfall-1.md
+  - content/dictionary/waterfall.md
+  - content/dictionary/webpack.md
+  - content/dictionary/white-space.md
+  - content/dictionary/whiteboard-interview.md
+  - content/dictionary/wireframe.md

--- a/content/dictionary/3-click-rule.md
+++ b/content/dictionary/3-click-rule.md
@@ -1,7 +1,6 @@
 ---
 title: 3-click Rule
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/5-planes.md
+++ b/content/dictionary/5-planes.md
@@ -1,7 +1,6 @@
 ---
 title: 5 Planes
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/60-30-10-rule.md
+++ b/content/dictionary/60-30-10-rule.md
@@ -1,7 +1,6 @@
 ---
 title: 60-30-10 Rule
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/80-20-rule.md
+++ b/content/dictionary/80-20-rule.md
@@ -1,7 +1,6 @@
 ---
 title: 80/20 Rule
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/adaptive.md
+++ b/content/dictionary/adaptive.md
@@ -1,7 +1,6 @@
 ---
 title: Adaptive
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/aesthetic.md
+++ b/content/dictionary/aesthetic.md
@@ -1,7 +1,6 @@
 ---
 title: Aesthetic
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/affordance.md
+++ b/content/dictionary/affordance.md
@@ -1,7 +1,6 @@
 ---
 title: Affordance
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/android.md
+++ b/content/dictionary/android.md
@@ -1,7 +1,6 @@
 ---
 title: Android
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/api.md
+++ b/content/dictionary/api.md
@@ -1,7 +1,6 @@
 ---
 title: API
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/avatar.md
+++ b/content/dictionary/avatar.md
@@ -1,7 +1,6 @@
 ---
 title: Avatar
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/backlog.md
+++ b/content/dictionary/backlog.md
@@ -1,7 +1,6 @@
 ---
 title: Backlog
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/brand-book.md
+++ b/content/dictionary/brand-book.md
@@ -1,7 +1,6 @@
 ---
 title: Brand Book
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/breadcrumb.md
+++ b/content/dictionary/breadcrumb.md
@@ -1,7 +1,6 @@
 ---
 title: Breadcrumb
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/cache.md
+++ b/content/dictionary/cache.md
@@ -1,7 +1,6 @@
 ---
 title: Cache
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/call-to-action-cta.md
+++ b/content/dictionary/call-to-action-cta.md
@@ -1,7 +1,6 @@
 ---
 title: Call to Action (CTA)
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/card-sorting.md
+++ b/content/dictionary/card-sorting.md
@@ -1,7 +1,6 @@
 ---
 title: Card Sorting
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/chatbot.md
+++ b/content/dictionary/chatbot.md
@@ -1,7 +1,6 @@
 ---
 title: Chatbot
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/clickstream.md
+++ b/content/dictionary/clickstream.md
@@ -1,7 +1,6 @@
 ---
 title: Clickstream
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/color-contrast.md
+++ b/content/dictionary/color-contrast.md
@@ -1,7 +1,6 @@
 ---
 title: Color Contrast
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/color-wheel.md
+++ b/content/dictionary/color-wheel.md
@@ -1,7 +1,6 @@
 ---
 title: Color Wheel
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/consistency.md
+++ b/content/dictionary/consistency.md
@@ -1,7 +1,6 @@
 ---
 title: Consistency
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/context-of-use-analysis.md
+++ b/content/dictionary/context-of-use-analysis.md
@@ -1,7 +1,6 @@
 ---
 title: Context of Use Analysis
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/conversion-rate-1.md
+++ b/content/dictionary/conversion-rate-1.md
@@ -1,7 +1,6 @@
 ---
 title: Conversion Rate
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/conversion-rate.md
+++ b/content/dictionary/conversion-rate.md
@@ -1,7 +1,6 @@
 ---
 title: " Conversion Rate"
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/corporate-identity-guideline.md
+++ b/content/dictionary/corporate-identity-guideline.md
@@ -1,7 +1,6 @@
 ---
 title: Corporate Identity Guideline
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/crazy-8s.md
+++ b/content/dictionary/crazy-8s.md
@@ -1,7 +1,6 @@
 ---
 title: Crazy 8s
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/crm.md
+++ b/content/dictionary/crm.md
@@ -1,7 +1,6 @@
 ---
 title: CRM
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/css.md
+++ b/content/dictionary/css.md
@@ -1,7 +1,6 @@
 ---
 title: CSS
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/customer-experience-cx.md
+++ b/content/dictionary/customer-experience-cx.md
@@ -1,7 +1,6 @@
 ---
 title: Customer Experience (CX)
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/customer-journey-map-cjm.md
+++ b/content/dictionary/customer-journey-map-cjm.md
@@ -1,7 +1,6 @@
 ---
 title: Customer Journey Map (CJM)
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/data-science.md
+++ b/content/dictionary/data-science.md
@@ -1,7 +1,6 @@
 ---
 title: Data Science
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/data-sets.md
+++ b/content/dictionary/data-sets.md
@@ -1,7 +1,6 @@
 ---
 title: Data sets
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/design-debt.md
+++ b/content/dictionary/design-debt.md
@@ -1,7 +1,6 @@
 ---
 title: Design Debt
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/design-thinking.md
+++ b/content/dictionary/design-thinking.md
@@ -1,7 +1,6 @@
 ---
 title: Design Thinking
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/diary-study.md
+++ b/content/dictionary/diary-study.md
@@ -1,7 +1,6 @@
 ---
 title: Diary Study
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/dots-per-inch-dpi.md
+++ b/content/dictionary/dots-per-inch-dpi.md
@@ -1,7 +1,6 @@
 ---
 title: Dots Per Inch (DPI)
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/empathy-map.md
+++ b/content/dictionary/empathy-map.md
@@ -1,7 +1,6 @@
 ---
 title: Empathy Map
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/end-user.md
+++ b/content/dictionary/end-user.md
@@ -1,7 +1,6 @@
 ---
 title: End User
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/end-users.md
+++ b/content/dictionary/end-users.md
@@ -1,7 +1,6 @@
 ---
 title: End Users
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/error-prevention.md
+++ b/content/dictionary/error-prevention.md
@@ -1,7 +1,6 @@
 ---
 title: Error prevention
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/eye-tracking.md
+++ b/content/dictionary/eye-tracking.md
@@ -1,7 +1,6 @@
 ---
 title: Eye Tracking
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/f-shaped-pattern.md
+++ b/content/dictionary/f-shaped-pattern.md
@@ -1,7 +1,6 @@
 ---
 title: F-Shaped Pattern
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/fishbone-diagram.md
+++ b/content/dictionary/fishbone-diagram.md
@@ -1,7 +1,6 @@
 ---
 title: Fishbone Diagram
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/fitts-law.md
+++ b/content/dictionary/fitts-law.md
@@ -1,7 +1,6 @@
 ---
 title: Fitts’ Law
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/flat-design.md
+++ b/content/dictionary/flat-design.md
@@ -1,7 +1,6 @@
 ---
 title: Flat Design
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/flowchart.md
+++ b/content/dictionary/flowchart.md
@@ -1,7 +1,6 @@
 ---
 title: Flowchart
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/gamification.md
+++ b/content/dictionary/gamification.md
@@ -1,7 +1,6 @@
 ---
 title: Gamification
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/gestalt-principles.md
+++ b/content/dictionary/gestalt-principles.md
@@ -1,7 +1,6 @@
 ---
 title: Gestalt Principles
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/golden-ratio.md
+++ b/content/dictionary/golden-ratio.md
@@ -1,7 +1,6 @@
 ---
 title: Golden Ratio
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/graphical-user-interface-gui.md
+++ b/content/dictionary/graphical-user-interface-gui.md
@@ -1,7 +1,6 @@
 ---
 title: Graphical User Interface (GUI)
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/grid-system.md
+++ b/content/dictionary/grid-system.md
@@ -1,7 +1,6 @@
 ---
 title: Grid System
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/grid.md
+++ b/content/dictionary/grid.md
@@ -1,7 +1,6 @@
 ---
 title: Grid
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/hardware.md
+++ b/content/dictionary/hardware.md
@@ -1,7 +1,6 @@
 ---
 title: Hardware
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/heat-map.md
+++ b/content/dictionary/heat-map.md
@@ -1,7 +1,6 @@
 ---
 title: Heat Map
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/heat-maps.md
+++ b/content/dictionary/heat-maps.md
@@ -1,7 +1,6 @@
 ---
 title: Heat Maps
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/hero-page.md
+++ b/content/dictionary/hero-page.md
@@ -1,7 +1,6 @@
 ---
 title: Hero Page
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/heuristic-evaluation.md
+++ b/content/dictionary/heuristic-evaluation.md
@@ -1,7 +1,6 @@
 ---
 title: Heuristic evaluation
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/human-computer-interaction.md
+++ b/content/dictionary/human-computer-interaction.md
@@ -1,7 +1,6 @@
 ---
 title: Human-Computer Interaction
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/hybrid-app.md
+++ b/content/dictionary/hybrid-app.md
@@ -1,7 +1,6 @@
 ---
 title: Hybrid App
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/information-architecture.md
+++ b/content/dictionary/information-architecture.md
@@ -1,7 +1,6 @@
 ---
 title: Information Architecture
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/interaction-design.md
+++ b/content/dictionary/interaction-design.md
@@ -1,7 +1,6 @@
 ---
 title: Interaction Design
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/ip-address.md
+++ b/content/dictionary/ip-address.md
@@ -1,7 +1,6 @@
 ---
 title: IP Address
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/iteration.md
+++ b/content/dictionary/iteration.md
@@ -1,7 +1,6 @@
 ---
 title: Iteration
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/landing-page-1.md
+++ b/content/dictionary/landing-page-1.md
@@ -1,7 +1,6 @@
 ---
 title: Landing Page
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/lean-ux.md
+++ b/content/dictionary/lean-ux.md
@@ -1,7 +1,6 @@
 ---
 title: Lean UX
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/material-design.md
+++ b/content/dictionary/material-design.md
@@ -1,7 +1,6 @@
 ---
 title: Material Design
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/mental-model.md
+++ b/content/dictionary/mental-model.md
@@ -1,7 +1,6 @@
 ---
 title: Mental Model
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/microcopy.md
+++ b/content/dictionary/microcopy.md
@@ -1,7 +1,6 @@
 ---
 title: Microcopy
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/mindmap.md
+++ b/content/dictionary/mindmap.md
@@ -1,7 +1,6 @@
 ---
 title: Mindmap
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/mobile-web.md
+++ b/content/dictionary/mobile-web.md
@@ -1,7 +1,6 @@
 ---
 title: Mobile Web
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/mockup.md
+++ b/content/dictionary/mockup.md
@@ -1,7 +1,6 @@
 ---
 title: Mockup
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/mvp.md
+++ b/content/dictionary/mvp.md
@@ -1,7 +1,6 @@
 ---
 title: MVP
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/pairing-development-pairing-programming.md
+++ b/content/dictionary/pairing-development-pairing-programming.md
@@ -1,7 +1,6 @@
 ---
 title: Pairing Development/Pairing Programming
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/png.md
+++ b/content/dictionary/png.md
@@ -1,7 +1,6 @@
 ---
 title: PNG
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/prototype.md
+++ b/content/dictionary/prototype.md
@@ -1,7 +1,6 @@
 ---
 title: Prototype
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/raw.md
+++ b/content/dictionary/raw.md
@@ -1,7 +1,6 @@
 ---
 title: RAW
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/refactoring.md
+++ b/content/dictionary/refactoring.md
@@ -1,7 +1,6 @@
 ---
 title: Refactoring
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/replaceme.md
+++ b/content/dictionary/replaceme.md
@@ -1,7 +1,6 @@
 ---
 title: replaceme
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/responsive.md
+++ b/content/dictionary/responsive.md
@@ -1,7 +1,6 @@
 ---
 title: Responsive
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/saas.md
+++ b/content/dictionary/saas.md
@@ -1,7 +1,6 @@
 ---
 title: SaaS
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/scrum.md
+++ b/content/dictionary/scrum.md
@@ -1,7 +1,6 @@
 ---
 title: Scrum
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/sdk.md
+++ b/content/dictionary/sdk.md
@@ -1,7 +1,6 @@
 ---
 title: SDK
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/seo.md
+++ b/content/dictionary/seo.md
@@ -1,7 +1,6 @@
 ---
 title: SEO
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/site-map.md
+++ b/content/dictionary/site-map.md
@@ -1,7 +1,6 @@
 ---
 title: Site map
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/sketching.md
+++ b/content/dictionary/sketching.md
@@ -1,7 +1,6 @@
 ---
 title: Sketching
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/slack.md
+++ b/content/dictionary/slack.md
@@ -1,7 +1,6 @@
 ---
 title: Slack
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/sprints.md
+++ b/content/dictionary/sprints.md
@@ -1,7 +1,6 @@
 ---
 title: Sprints
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/storyboard.md
+++ b/content/dictionary/storyboard.md
@@ -1,7 +1,6 @@
 ---
 title: Storyboard
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/svg.md
+++ b/content/dictionary/svg.md
@@ -1,7 +1,6 @@
 ---
 title: SVG
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/task-analysis.md
+++ b/content/dictionary/task-analysis.md
@@ -1,7 +1,6 @@
 ---
 title: Task Analysis
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/technical-debt-1.md
+++ b/content/dictionary/technical-debt-1.md
@@ -1,7 +1,6 @@
 ---
 title: Technical Debt
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/ui-element.md
+++ b/content/dictionary/ui-element.md
@@ -1,7 +1,6 @@
 ---
 title: UI Element
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/ui-pattern.md
+++ b/content/dictionary/ui-pattern.md
@@ -1,7 +1,6 @@
 ---
 title: UI Pattern
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/unit-testing.md
+++ b/content/dictionary/unit-testing.md
@@ -1,7 +1,6 @@
 ---
 title: Unit Testing
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/usability-testing.md
+++ b/content/dictionary/usability-testing.md
@@ -1,7 +1,6 @@
 ---
 title: Usability Testing
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/user-centered-design.md
+++ b/content/dictionary/user-centered-design.md
@@ -1,7 +1,6 @@
 ---
 title: User-Centered Design
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/user-engagement.md
+++ b/content/dictionary/user-engagement.md
@@ -1,7 +1,6 @@
 ---
 title: User Engagement
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/user-experience-ux.md
+++ b/content/dictionary/user-experience-ux.md
@@ -1,7 +1,6 @@
 ---
 title: User Experience (UX)
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/user-flow.md
+++ b/content/dictionary/user-flow.md
@@ -1,7 +1,6 @@
 ---
 title: User Flow
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/user-interface.md
+++ b/content/dictionary/user-interface.md
@@ -1,7 +1,6 @@
 ---
 title: User Interface
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/user-journey-maps.md
+++ b/content/dictionary/user-journey-maps.md
@@ -1,7 +1,6 @@
 ---
 title: User Journey Maps
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/user-research.md
+++ b/content/dictionary/user-research.md
@@ -1,7 +1,6 @@
 ---
 title: User Research
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/user-scenario.md
+++ b/content/dictionary/user-scenario.md
@@ -1,7 +1,6 @@
 ---
 title: User Scenario
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/user-stories.md
+++ b/content/dictionary/user-stories.md
@@ -1,7 +1,6 @@
 ---
 title: User Stories
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/vertical-rhythm.md
+++ b/content/dictionary/vertical-rhythm.md
@@ -1,7 +1,6 @@
 ---
 title: Vertical Rhythm
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/visibility-of-system-status.md
+++ b/content/dictionary/visibility-of-system-status.md
@@ -1,7 +1,6 @@
 ---
 title: Visibility of system status
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/waterfall-1.md
+++ b/content/dictionary/waterfall-1.md
@@ -1,7 +1,6 @@
 ---
 title: Waterfall
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/white-space.md
+++ b/content/dictionary/white-space.md
@@ -1,7 +1,6 @@
 ---
 title: White space
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---

--- a/content/dictionary/whiteboard-interview.md
+++ b/content/dictionary/whiteboard-interview.md
@@ -1,7 +1,6 @@
 ---
 title: Whiteboard Interview
-definition: replace with with your own definition
+definition:
 sources: []
 perspectives: []
-
 ---


### PR DESCRIPTION
## This PR fixes...

This PR removed the default text from dictionary entries which do not have any info.

## What I did...

Did find and replace on the markdown files that had the default text

## How to test...

- Go to /dictionary
- Ctrl+F to search for "replace with your own definition." See that nothing comes up.

## I learned...

I need some sleeeeep. 😪 
