### PR TITLE
Fix/homepage bg

### DIFF
--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -1,31 +1,33 @@
 <template>
   <main @keydown.esc="showDialog = false" class="pb-6 wrapper">
-    <div
-      :aria-hidden="hideContentAria"
-      class="flex flex-col items-center max-w-screen-md px-5 mx-auto my-0"
-    >
-      <g-image
-        class="pt-10 m-3 max-w-screen lg:max-w-lg"
-        width="500"
-        src="~/assets/images/cot-name.png"
-        alt="Coming Soon - Cherry on Tech"
-      />
-
-      <h1
-        class="font-serif text-5xl font-bold text-center text-white uppercase"
+    <div class="pb-12 bg-cover bg-outerspace">
+      <div
+        :aria-hidden="hideContentAria"
+        class="flex flex-col items-center max-w-screen-md px-5 mx-auto my-0"
       >
-        We are a tech squad
-      </h1>
+        <g-image
+          class="pt-10 m-3 max-w-screen lg:max-w-lg"
+          width="500"
+          src="~/assets/images/cot-name.png"
+          alt="Coming Soon - Cherry on Tech"
+        />
 
-      <h2 class="max-w-sm mb-4 text-2xl text-center text-white font-orbitron">
-        We dream, scheme, and support each other in our careers
-      </h2>
-      <BaseButton
-        @click="showDialog = true"
-        class="font-sans font-extrabold uppercase bg-gray-100"
-        >Keep me updated</BaseButton
-      >
-      <Dialog v-if="showDialog === true" @close="showDialog = false" />
+        <h1
+          class="font-serif text-5xl font-bold text-center text-white uppercase"
+        >
+          We are a tech squad
+        </h1>
+
+        <h2 class="max-w-sm mb-4 text-2xl text-center text-white font-orbitron">
+          We dream, scheme, and support each other in our careers
+        </h2>
+        <BaseButton
+          @click="showDialog = true"
+          class="font-sans font-extrabold uppercase bg-gray-100"
+          >Keep me updated</BaseButton
+        >
+        <Dialog v-if="showDialog === true" @close="showDialog = false" />
+      </div>
     </div>
   </main>
 </template>
@@ -54,10 +56,7 @@ export default {
 
 <style scoped>
 .wrapper {
-  background-image: url("../../static/homepage-bg.png");
   background-color: #8878a5;
-  background-size: cover;
-  background-position: center top;
   min-height: 100vh;
 }
 </style>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,5 +7,11 @@ module.exports = {
       serif: ["Nunito", ...defaultTheme.fontFamily.serif],
       orbitron: ["Orbitron", "sans-serif"],
     },
+    extend: {
+      backgroundImage: {
+        // Background images are relative to main.css
+        'outerspace': "url('assets/images/outerspace.png')"
+      }
+    }
   },
 };


### PR DESCRIPTION
## This PR fixes...

1. Hopefully fixes #8, and optimizes the outerspace image that currently sits on the homepage. Update: it does not in fact optimize the image. 
1. Allows us to use the background image as a TW class. This lets us use the same image as many times as we want, as a background class. Much better for dev experience and I think better for overall load time.

## What I did...

- Added the outerspace image into the assets folder
- Made the outerspace image into a background class available through Tailwind

## How to test...

- Go to the homepage of the preview deploy
- See that it looks like this
![Screen Shot 2020-10-10 at 8 51 24 PM](https://user-images.githubusercontent.com/38117965/95667905-68408680-0b3a-11eb-86c8-688cff85e286.png)


## I learned...

