### PR TITLE
Add and use vue-gtag as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "tailwindcss": "^1.8.13",
     "typeface-nunito": "^1.1.3",
     "typeface-nunito-sans": "^0.0.72",
-    "typeface-orbitron": "^1.1.3"
+    "typeface-orbitron": "^1.1.3",
+    "vue-gtag": "^1.9.1"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -2,11 +2,15 @@
 // The Client API can be used here. Learn more: gridsome.org/docs/client-api
 require('~/main.css')
 
+import VueGtag from "vue-gtag";
 import DefaultLayout from "~/layouts/Default.vue";
 
 export default function(Vue, { router, head, isClient }) {
   // Set default layout as a global component
   Vue.component("Layout", DefaultLayout);
+  Vue.use(VueGtag, {
+  config: { id: "UA-1234567-1" }
+});
 }
 
 // Require our fonts globally

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ export default function(Vue, { router, head, isClient }) {
   // Set default layout as a global component
   Vue.component("Layout", DefaultLayout);
   Vue.use(VueGtag, {
-  config: { id: "UA-1234567-1" }
+  config: { id: "G-6P9YW352WJ" }
 });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9501,6 +9501,11 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
+vue-gtag@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/vue-gtag/-/vue-gtag-1.9.1.tgz#d5b20774b298e3aa330580d66783715fd3eded16"
+  integrity sha512-pVQyBaczTR7ZYxuxu8JjbHP8p41o1G/5hBDykONpU6EyRsHHx/B7PO2ZtW38/QYn0msuSyGkWulS1tliLuOXLQ==
+
 vue-hot-reload-api@^2.3.0:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"


### PR DESCRIPTION
## This PR fixes...

This PR fixes #20 - it adds a google analytics tag via `vue-gtag` plugin.

## What I did...

- added `vue-gtag` as a dependency
- added the `Vue.use` script to `main.js`

## How to test...

Open devtools on the site.
Check on the network tab that google analytics is being pulled in
Check on the elements tab that google script is in the head

## I learned...

I hope this works! I don't know if it will work on the deploy preview site or if it needs to be live.

Resources used:
- [How to add external scripts on Gridsome](https://gridsome.org/docs/assets-scripts/#using-an-external-vue-plugin-1)
- [Vue-gtag plugin](https://github.com/MatteoGabriele/vue-gtag) - note that I was thinking of using the official plugin, but the package on which it's based (vue-analytics) says to use vue-gtag.