### PR TITLE
Add a hero slot and use on About page

### DIFF
--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -2,8 +2,11 @@
   <div class="h-screen">
     <div class="flex flex-col items-stretch justify-between h-full">
       <Header />
-      <div class="flex-grow p-6">
-        <slot />
+      <div class="flex-grow">
+        <slot name="hero"/>
+        <div class="p-6">
+          <slot />
+        </div>
       </div>
       <div>
         <Footer />

--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -1,6 +1,18 @@
 <template>
   <Layout>
-    <h1>About us</h1>
+    <template v-slot:hero>
+    <div class="w-screen py-24 bg-gray-100">
+      <div class="grid max-w-screen-lg m-auto md:grid-cols-2 md:gap-8">
+        <div>
+          <h1 class="font-serif text-5xl font-bold leading-relaxed">About us</h1>
+          <p class="text-3xl">
+            <span class="font-bold">Cherry on Tech</span> is a volunteer run organization whose mission is to support people of marginalized genders who are new into the world of tech. We are dedicated to developing and creating a community that focuses on empowering women while promoting the power of being part of a <span class="font-bold">tech squad</span>.
+          </p>
+        </div>
+      </div>
+    </div>
+    </template>
+    
     <div class="grid max-w-screen-lg m-auto md:grid-cols-3 md:gap-8">
       <article
         v-for="(member, index) in $page.bios.edges"


### PR DESCRIPTION
## This PR fixes...

Ex: This PR fixes #119 - it adds an hero section to the About page

## What I did...

- added a slot in the default layout so that other pages can use it to make hero sections
- added content on the about page

## How to test...

1. Navigate to /about
2. See that the hero section now exists and looks roughly like the Figma.
Caveats: There is no "join a tech squad" button because I don't think we know where that will lead just yet.

## I learned...

For future @fdmmarshall && @Dreamy26 - we should create a standardized hero component with props and slots for colors and content.