### PR TITLE
Add, style, and use DictionaryCard

### DIFF
--- a/src/components/cards/DictionaryCard.vue
+++ b/src/components/cards/DictionaryCard.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="flex flex-col border border-gray-900 md:flex-row">
+  <div class="flex flex-col text-3xl border border-gray-900 md:flex-row">
 
   <!-- Entry name -->
     <div 
       class="flex flex-col justify-between w-1/2 pt-8 pl-8 pr-16 md:border-r md:border-gray-200"
       :class="post.node.perspectives.length ? 'pb-4' : 'pb-8'"
     >
-      <g-link :to="post.node.path" class="font-bold">{{
+      <g-link :to="post.node.path" class="text-3xl font-bold">{{
         post.node.title
       }}</g-link>
 

--- a/src/components/cards/DictionaryCard.vue
+++ b/src/components/cards/DictionaryCard.vue
@@ -1,0 +1,115 @@
+<template>
+  <div class="flex flex-col border border-gray-900 md:flex-row">
+
+  <!-- Entry name -->
+    <div 
+      class="flex flex-col justify-between w-1/2 pt-8 pl-8 pr-16 md:border-r md:border-gray-200"
+      :class="post.node.perspectives.length ? 'pb-4' : 'pb-8'"
+    >
+      <g-link :to="post.node.path" class="font-bold">{{
+        post.node.title
+      }}</g-link>
+
+      <div 
+        v-if="post.node.perspectives.length || post.node.definition"
+        class="flex justify-between"
+      >
+        <g-link
+          :to="
+            `https://github.com/cherryontech/website/blob/pit/src/assets/content/${
+              post.node.fileInfo.path
+            }`
+          "
+          class="text-pink-700 underline"
+        >
+          add your perspective
+        </g-link>
+        
+        <g-link
+          :to="
+            `https://github.com/cherryontech/website/blob/pit/src/assets/content/${
+              post.node.fileInfo.path
+            }`
+          "
+          class="text-pink-700 underline"
+          >
+            {{ post.node.definition ? 'edit this definition' : 'add a definition' }}
+          </g-link>
+      </div>
+    </div>
+
+  <!-- Entry definition and perspective -->
+    <div class="flex flex-col w-1/2">
+
+      <!-- Definition -->
+      <div 
+        v-if="post.node.definition"
+        class="pl-16 pr-8 border-b border-gray-200 py-7"
+      >
+        <p class="font-bold">Definition</p>
+        <p>{{ post.node.definition }}</p>
+      </div>
+      
+      <!-- Perspective -->
+      <div 
+        v-if="post.node.perspectives.length"
+        class="pl-16 pr-8 my-7"
+      >
+        <p class="font-bold">Perspectives</p>
+        <div 
+          v-for="(perspective, index) in post.node.perspectives" 
+          :key="index"
+        >
+          <p>
+            As a <em>{{ perspective.role }}</em
+            >, <span v-if="post.node.title">"{{ post.node.title }}"</span> means
+            {{ perspective.meaning }}.
+          </p>
+        </div>
+      </div>
+
+      <!-- If no contribs yet -->
+      <div
+        v-if="!post.node.perspectives.length && !post.node.definition"
+        class="flex justify-between px-16 py-7"
+      >
+        <g-link
+          :to="
+            `https://github.com/cherryontech/website/blob/pit/src/assets/content/${
+              post.node.fileInfo.path
+            }`
+          "
+          class="text-pink-700 underline"
+        >
+          add your perspective
+        </g-link>
+        
+        <g-link
+          :to="
+            `https://github.com/cherryontech/website/blob/pit/src/assets/content/${
+              post.node.fileInfo.path
+            }`
+          "
+          class="text-pink-700 underline"
+          >
+            add a definition
+        </g-link>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+    export default {
+        props: {
+            post: {
+                type: Object,
+                required: true
+            },
+        },
+    }
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/src/pages/Dictionary.vue
+++ b/src/pages/Dictionary.vue
@@ -28,6 +28,7 @@
       v-for="post in filteredTerms"
       :key="post.id"
       :post="post"
+      class="mb-4 last:mb-0"
     />
   </Layout>
 </template>

--- a/src/pages/Dictionary.vue
+++ b/src/pages/Dictionary.vue
@@ -24,36 +24,11 @@
       placeholderText="type a word"
       class="mb-2"
     />
-    <div
+    <DictionaryCard
       v-for="post in filteredTerms"
       :key="post.id"
-      class="py-2 border-t border-purple-900"
-    >
-      <g-link
-        v-if="!post.node.definition && !post.node.perspectives.length"
-        :to="
-          `https://github.com/cherryontech/website/blob/pit/src/assets/content/${
-            post.node.fileInfo.path
-          }`
-        "
-        class="font-bold"
-        >{{ post.node.title }}
-        <span class="font-normal"
-          >doesn't have any definition or perspectives yet.</span
-        ><span class="font-normal underline"> Add yours!</span></g-link
-      >
-      <g-link v-else :to="post.node.path" class="font-bold">{{
-        post.node.title
-      }}</g-link>
-      <p class="italic">{{ post.node.definition }}</p>
-      <div v-for="(perspective, index) in post.node.perspectives" :key="index">
-        <p>
-          As a <em>{{ perspective.role }}</em
-          >, <span v-if="post.node.title">"{{ post.node.title }}"</span> means
-          {{ perspective.meaning }}.
-        </p>
-      </div>
-    </div>
+      :post="post"
+    />
   </Layout>
 </template>
 
@@ -81,10 +56,12 @@ query Dictionaryposts {
 
 <script>
 import SearchBar from "@/components/controls/SearchBar.vue";
+import DictionaryCard from '@/components/cards/DictionaryCard.vue';
 
 export default {
   components: {
     SearchBar,
+    DictionaryCard
   },
   metaInfo: {
     title: "Dictionary",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,5 +21,6 @@ module.exports = {
   variants: {
     textColor: ['responsive', 'hover', 'active'],
     backgroundColor: ['responsive', 'hover', 'active'],
+    margin: ['last']
   }
 };


### PR DESCRIPTION
## This PR fixes...
This PR addresses #121 

Note: The `DictionaryCard` doesn't look exactly like the [Figma](https://www.figma.com/file/ZXg4cpbcI0gpsgzCnjfsJT/Cherry-on-top?node-id=654%3A1738), but it supports some more cases that the Figma didn't cover. Will have @julietafb take a look and we can perhaps modify in a future PR.

## What I did...

- Added a `DictionaryCard` component
- Styled `DictionaryCard` component ~ [Figma](https://www.figma.com/file/ZXg4cpbcI0gpsgzCnjfsJT/Cherry-on-top?node-id=654%3A1738)

## How to test...

- Navigate to /dictionary
- See that dictionary entries each appear with correct content
- Check that links to add new perspective and add a definition lead to working Github files

## I learned...

I added the `last` variant to the Tailwind config file - [here's how](https://tailwindcss.com/docs/configuring-variants#overview). Keep this in mind if a Tailwind property is not working for you (this is what happened to me!). Read the docs to see if it must be added as a variant first.

