### PR TITLE
Add a dictionary definition for Conversion rate

### DIFF
--- a/src/assets/content/dictionary/conversion-rate.md
+++ b/src/assets/content/dictionary/conversion-rate.md
@@ -1,6 +1,10 @@
 ---
-title: " Conversion Rate"
-definition:
-sources: []
-perspectives: []
+title: Conversion rate
+definition: The percentage of users who take a desired action
+sources:
+- sourceurl: https://www.nngroup.com/articles/conversion-rates/
+perspectives:
+- meaning: the rate at which users respond to a Call to Action
+  role: UX specialist
 ---
+


### PR DESCRIPTION
## This PR fixes...

This PR updates the dictionary area of the website.

## What I did...

I added a definition, a link to NNGroup, and a perspective.

## How to test...

Go to the Dictionary page. See that the entry for "Conversion rate" has been filled out and looks ok!

## I learned...

I learned our formatting might be slightly different between the "How to contribute" document and the template. We might need to update the documentation!
