### PR TITLE
Add a dictionary definition for A/B Testing

### DIFF
--- a/src/assets/content/dictionary/a-b-testing.md
+++ b/src/assets/content/dictionary/a-b-testing.md
@@ -1,6 +1,6 @@
 ---
 title: A/B Testing
-definition: 'A/B testing is a UX Methodology where two variables are randomly tested on participants'
+definition: 'A/B testing is a UX methodology where two variables are randomly tested on participants'
 sources:
 - sourceurl: https://vwo.com/ab-testing/
 perspectives:

--- a/src/assets/content/dictionary/a-b-testing.md
+++ b/src/assets/content/dictionary/a-b-testing.md
@@ -1,7 +1,10 @@
 ---
 title: A/B Testing
-definition: ''
-sources: []
-perspectives: []
+definition: 'A/B testing is a UX Methodology where two variables are randomly tested on participants'
+sources:
+- sourceurl: https://vwo.com/ab-testing/
+perspectives:
+- meaning: a technique that's useful when I'm not sure about one specific part of a design and want to gain insight
+  role: Designer
 
 ---


### PR DESCRIPTION
## This PR fixes...

The lack of dictionary definition for A/B testing
## What I did...

- Added dictionary definition for A/B testing based on source
- Added designer perspective

## How to test...

1. Navigate to /dictionary
1. Search 'A/B Testing'
1. See if dictionary definition and designer perspective is added
2. Check for grammar errors or typos

## I learned...
