### PR TITLE
Fix: Portfolio site leads to 404 

### DIFF
--- a/src/libraries/utils.js
+++ b/src/libraries/utils.js
@@ -12,7 +12,7 @@
     const trimmedUrl = url.trim();
   
     if (trimmedUrl.includes(https) || trimmedUrl.includes("http://")) {
-      return url;
+      return trimmedUrl;
     }
     return https + trimmedUrl;
   };

--- a/src/libraries/utils.js
+++ b/src/libraries/utils.js
@@ -1,3 +1,13 @@
+/**
+ * Verifies whether the url starts with http:// or https://
+ * @function
+ * @param {string} url - The url of the portfolio site
+ * @returns {boolean} 
+ */
+ const isValidUrl = (url) => {
+  return url.indexOf("https://") === 0 || url.indexOf("http://") === 0
+ }
+ 
  /**
  * Our CMS does not validate urls,
  * urls are entered in manually by the author,
@@ -11,7 +21,7 @@
     const https = "https://";
     const trimmedUrl = url.trim();
   
-    if (trimmedUrl.includes(https) || trimmedUrl.includes("http://")) {
+    if (isValidUrl(trimmedUrl)) {
       return trimmedUrl;
     }
     return https + trimmedUrl;

--- a/src/libraries/utils.js
+++ b/src/libraries/utils.js
@@ -1,0 +1,11 @@
+// Our CMS does not validate urls,
+// urls are entered in manually by the author,
+// so this is to ensure a valid url to navigate to
+const validPortfolioUrl = (url = "") => {
+    const https = "https://";
+  
+    if (url.includes(https) || url.includes("http://")) {
+      return url;
+    }
+    return https + url;
+  };

--- a/src/libraries/utils.js
+++ b/src/libraries/utils.js
@@ -1,11 +1,18 @@
-// Our CMS does not validate urls,
-// urls are entered in manually by the author,
-// so this is to ensure a valid url to navigate to
-const validPortfolioUrl = (url = "") => {
+ /**
+ * Our CMS does not validate urls,
+ * urls are entered in manually by the author,
+ * so this is to ensure a valid url to navigate to
+ * @function
+ * @param {string} url - The url of the portfolio site
+ * @returns {string} url - The passed in url or a new url 
+ * with https appended to it
+ */
+ export const validUrl = (url = "") => {
     const https = "https://";
+    const trimmedUrl = url.trim();
   
-    if (url.includes(https) || url.includes("http://")) {
+    if (trimmedUrl.includes(https) || trimmedUrl.includes("http://")) {
       return url;
     }
-    return https + url;
+    return https + trimmedUrl;
   };

--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -47,7 +47,7 @@
         <a
           class="ml-auto text-xl font-extrabold"
           v-if="member.node.contact_links.portfolio_url"
-          :href="member.node.contact_links.portfolio_url"
+          :href="validUrl(member.node.contact_links.portfolio_url)"
           >site</a
         >
       </article>
@@ -86,9 +86,14 @@ query
 </page-query>
 
 <script>
+import {validUrl} from "../libraries/utils";  
 export default {
   metaInfo: {
     title: "About us",
   },
+  methods: {
+    validUrl
+  }
+
 };
 </script>

--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -91,9 +91,16 @@ export default {
   metaInfo: {
     title: "About us",
   },
-  methods: {
+    methods: {
     validUrl
   }
-
+  // methods: {
+  //   validUrl
+  // },
+  // computed: {
+  //   portfolioUrl() {
+  //     // return this.validUrl(member.node.contact_links.portfolio_url)
+  //  }
+  // }
 };
 </script>

--- a/src/templates/Biopost.vue
+++ b/src/templates/Biopost.vue
@@ -16,13 +16,13 @@
         />
         <a
           v-if="$page.biopost.contact_links.email"
-          :href="`mailto:${$page.biopost.contact_links.email}`"
+          href="`mailto:${$page.biopost.contact_links.email}`"
           class="font-bold underline"
           >Email</a
         >
         <a
           v-if="$page.biopost.contact_links.portfolio_url"
-          :href="$page.biopost.contact_links.portfolio_url"
+          :href="validUrl($page.biopost.contact_links.portfolio_url)"
           class="font-bold underline"
           >Portfolio</a
         >
@@ -63,12 +63,16 @@
 </template>
 
 <script>
+import {validUrl} from "../libraries/utils";
 export default {
   metaInfo() {
     return {
       title: this.$page.biopost.title,
     };
   },
+  methods: {
+    validUrl
+  }
 };
 </script>
 

--- a/src/templates/Biopost.vue
+++ b/src/templates/Biopost.vue
@@ -22,7 +22,7 @@
         >
         <a
           v-if="$page.biopost.contact_links.portfolio_url"
-          :href="validUrl($page.biopost.contact_links.portfolio_url)"
+          :href="portfolioUrl"
           class="font-bold underline"
           >Portfolio</a
         >
@@ -72,6 +72,11 @@ export default {
   },
   methods: {
     validUrl
+  },
+  computed: {
+    portfolioUrl() {
+      return this.validUrl(this.$page.biopost.contact_links.portfolio_url)
+    }
   }
 };
 </script>


### PR DESCRIPTION
## This PR fixes...

This PR fixes #147. Appends 'https://' to the urls that do not have 'http://' or 'https://' so that the link navigates to the site instead of 404 error page.

## What I did...

- add libraries folder and utils file
- add util function for validating and mutating the url
- pass all urls into util function

## How to test...

1. Navigate to http://localhost:8080/about/
2. Click 'site' for each card that contains a site button
3. Verify that it navigates to their website and not a 404 error page
4. Navigate to the bio page (ex: http://localhost:8080/bio/julieth-fajardo/) for each card that contains a site button 
5. Click on the 'Portfolio' link
6. Verify that it navigates to their website and not a 404 error page