### PR TITLE
Add dictionary definition for "CSS"

### DIFF
--- a/src/assets/content/dictionary/application-programming-interface-api.md
+++ b/src/assets/content/dictionary/application-programming-interface-api.md
@@ -1,6 +1,10 @@
----
-title: Application Programming Interface (API)
-definition: ''
-perspectives: []
+
+title: Cascading Style Sheets (CSS)
+definition: CSS stands for Cascading Style Sheets and is used to stylize elements written in a markup language such as HTML. It separates the content from the visual representation of the site.
+sources:
+- sourceurl: https://www.hostinger.com/tutorials/what-is-css
+perspectives:
+- meaning: with CSS, we are able to create rules, and apply those rules to many elements within the website. This approach offers many advantages when site-wide changes are required by a client
+  role: developer
 
 ---


### PR DESCRIPTION
Cascading Style Sheets (CSS)

## This PR fixes...

The lack of dictionary definition and perspective  for "Cascading Style Sheets (CSS).


## What I did...

- Add dictionary definition for CSS 
- Add dictionary perspective for CSS

## How to test...



1. Navigate to /dictionary
1. Search "Cascading Style Sheets (CSS)
1. See if definition and perspective shows up under term "Cascading Style Sheets (CSS) 
2. Check grammar and typos 

## I learned...

It's my first open source project contribution and I had lots of fun! 
