### PR TITLE
Add dictionary definition for 'bug'

### DIFF
--- a/src/assets/content/dictionary/bug.md
+++ b/src/assets/content/dictionary/bug.md
@@ -1,6 +1,12 @@
 ---
-title: bug
-definition: ''
-perspectives: []
+title: bugs
+definition: 'a bug is a coding error, flaw, or defect. It is frequently used in technology as a coding error in software or hardware programs that results in an unexpected outcome. Here is an example of bugs on a error prone website:
 
+users attempt to login but are unable to do so, or clickable buttons or elements fail to function.'
+sources:
+- sourceurl: https://en.wikipedia.org/wiki/Software_bug
+perspectives:
+- meaning: as a frontend developer, the term bug refers to a mistake I made that causes the program to fail to function as described by the program's requirements.
+  role: developer
+  
 ---


### PR DESCRIPTION
## This PR fixes...

The lack of dictionary definition and perspective for 'bug'


## What I did...


- Add dictionary definition for bug
- Add perspective definition for bug

## How to test...



1. Navigate to /dictionary
1. Search 'bug'
1. See if definition and perspective shows up under term 'bug'
2. Check grammar and typos

## I learned...

I had a lot of fun :)
