### PR TITLE
Add dictionary definition for "API"

### DIFF
--- a/src/assets/content/dictionary/application-programming-interface-api.md
+++ b/src/assets/content/dictionary/application-programming-interface-api.md
@@ -1,6 +1,11 @@
 ---
 title: Application Programming Interface (API)
-definition: ''
+definition: 'The word Application refers to any software with a distinct function, and interface can be thought as a contract of service between two applications.This contract defines how the two communicate with each other using requests and responses. 
+
+Then a API sets contracts with defined rules that explain how computers or applications communicate with one another.This allows services and products to communicate with each other and leverage each other's data and functionality through a documented interface.'.
+sources:
+- sourceurl: https://www.ibm.com/cloud/learn/api
+- sourceurl: https://aws.amazon.com/what-is/api/?nc1=h_ls
 perspectives: []
 
 ---

--- a/src/assets/content/dictionary/application-programming-interface-api.md
+++ b/src/assets/content/dictionary/application-programming-interface-api.md
@@ -1,8 +1,15 @@
 ---
 title: Application Programming Interface (API)
-definition: "The word Application refers to any software with a distinct function, and interface can be thought as a contract of service between two applications. This contract defines how the two communicate with each other using requests and responses. 
+definition: "The word Application refers to any software with a distinct function, and interface can be thought as a contract of service between two applications. 
 
-Then a API sets contracts with defined rules that explain how computers or applications communicate with one another. This allows services and products to communicate with each other and leverage each other's data and functionality through a documented interface."
+
+This contract defines how the two communicate with each other using requests and responses. 
+
+
+Then a API sets contracts with defined rules that explain how computers or applications communicate with one another. 
+
+
+This allows services and products to communicate with each other and leverage each other's data and functionality through a documented interface."
 sources:
 - sourceurl: https://www.ibm.com/cloud/learn/api
 - sourceurl: https://aws.amazon.com/what-is/api/?nc1=h_ls

--- a/src/assets/content/dictionary/application-programming-interface-api.md
+++ b/src/assets/content/dictionary/application-programming-interface-api.md
@@ -1,8 +1,8 @@
 ---
 title: Application Programming Interface (API)
-definition: 'The word Application refers to any software with a distinct function, and interface can be thought as a contract of service between two applications.This contract defines how the two communicate with each other using requests and responses. 
+definition: "The word Application refers to any software with a distinct function, and interface can be thought as a contract of service between two applications. This contract defines how the two communicate with each other using requests and responses. 
 
-Then a API sets contracts with defined rules that explain how computers or applications communicate with one another.This allows services and products to communicate with each other and leverage each other's data and functionality through a documented interface.'.
+Then a API sets contracts with defined rules that explain how computers or applications communicate with one another. This allows services and products to communicate with each other and leverage each other's data and functionality through a documented interface."
 sources:
 - sourceurl: https://www.ibm.com/cloud/learn/api
 - sourceurl: https://aws.amazon.com/what-is/api/?nc1=h_ls


### PR DESCRIPTION
## This PR fixes...

The lack of dictionary definition for Application Programming Interface(API)

## What I did...

- Add dictionary definition for API

## How to test...

_In a list format, tell us how to test this PR._
Ex:

1. Navigate to /dictionary
1. Search "Application Programming Interface(API)"
1. See if the definition appears under the term "Application Programming Interface(API)"

## I learned...
A deeper understanding of the APIs as a whole.
