### PR TITLE
Add dictionary definition for "API"

### DIFF
--- a/src/assets/content/dictionary/application-programming-interface-api.md
+++ b/src/assets/content/dictionary/application-programming-interface-api.md
@@ -1,6 +1,8 @@
 ---
 title: Application Programming Interface (API)
-definition: ''
+definition: 'The word Application refers to any software with a distinct function, and interface can be thought as a contract of service between two applications.This contract defines how the two communicate with each other using requests and responses. 
+Then a API sets contracts with defined rules that explain how computers or applications communicate with one another.This allows services and products to communicate with each other and leverage each other's data and functionality through a documented interface.'.
+sources: https://www.ibm.com/cloud/learn/api
 perspectives: []
 
 ---


### PR DESCRIPTION
## This PR fixes...

The lack of dictionary definition for Application Programming Interface(API)

## What I did...

- Add dictionary definition for API

## How to test...

1.Navigate to /dictionary
1.Search "Application Programming Interface(API)"
1.See if the definition appears under the term "Application Programming Interface(API)"

## I learned...

A deeper understanding of the APIs as a whole.