### PR TITLE
Add dictionary definition for "JavaScript"

### DIFF
--- a/src/assets/content/dictionary/javascript.md
+++ b/src/assets/content/dictionary/javascript.md
@@ -1,7 +1,7 @@
 ---
 title: JavaScript 
 definition: 'JavaScript is a programming or scripting language that allows one to create a dynamic or complex webpage.
- Features such as interactive maps, animated graphics, multimedia functionalities and many more are all created with Javascript. It is referred to as the third layer in the three layers of standard web technologies'
+ Features such as interactive maps, animated graphics, multimedia functionalities and many more are all created with Javascript. It is referred to as the third layer in the three layers of standard web technologies.'
 sources:
 - sourceurl: https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/What_is_JavaScript
 perspectives:

--- a/src/assets/content/dictionary/javascript.md
+++ b/src/assets/content/dictionary/javascript.md
@@ -1,6 +1,10 @@
 ---
-title: JavaScript
-definition: ''
-perspectives: []
-
+title: JavaScript 
+definition: 'JavaScript is a programming or scripting language that allows one to create a dynamic or complex webpage.
+ Features such as interactive maps, animated graphics, multimedia functionalities and many more are all created with Javascript. It is referred to as the third layer in the three layers of standard web technologies'
+sources:
+- sourceurl: https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/What_is_JavaScript
+perspectives:
+- meaning: is a programming language used to bring concepts to life. It is responsible for implementing designs and site interactions
+  role: frontend developer
 ---

--- a/src/assets/content/dictionary/javascript.md
+++ b/src/assets/content/dictionary/javascript.md
@@ -5,6 +5,6 @@ definition: 'JavaScript is a programming or scripting language that allows one t
 sources:
 - sourceurl: https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/What_is_JavaScript
 perspectives:
-- meaning: is a programming language used to bring concepts to life. It is responsible for implementing designs and site interactions
+- meaning: a programming language I can use to bring concepts to life. I can use it to implement designs and site interactions.
   role: frontend developer
 ---


### PR DESCRIPTION
## This PR fixes...

The lack of dictionary definition and perspective for "JavaScript"

## What I did...


- Add dictionary definition for JavaScript
- Add frontend developer perspective for JavaScript

## How to test...

_In a list format, tell us how to test this PR._
Ex:

1. Navigate to /dictionary
1. Search for "JavaScript"
1. See if definition and perspective show up under the term "JavaScript"
2. Check grammar and typos

## I learned...

I had fun!
