### PR TITLE
Add a dictionary definition for "React"

### DIFF
--- a/src/assets/content/dictionary/react.md
+++ b/src/assets/content/dictionary/react.md
@@ -1,6 +1,6 @@
 ---
 title: React
-definition: 'React is an open-source JavaScript library for building user interfaces. It is not exclusive to the web rather it is used with other libraries to render to certain environments. Its component-based library lets you build high quality user interfaces for webpages'
+definition: 'React is an open-source JavaScript library for building user interfaces. It is not exclusive to the web rather it is used with other libraries to render to certain environments. Its component-based library lets you build high quality user interfaces for webpages.'
 sources:
 - sourceurl: https://reactjs.org/
 ---

--- a/src/assets/content/dictionary/react.md
+++ b/src/assets/content/dictionary/react.md
@@ -1,6 +1,6 @@
 ---
 title: React
-definition: ''
-perspectives: []
-
+definition: 'React is an open-source JavaScript library for building user interfaces. It is not exclusive to the web rather it is used with other libraries to render to certain environments. Its component-based library lets you build high quality user interfaces for webpages'
+sources:
+- sourceurl: https://reactjs.org/
 ---


### PR DESCRIPTION
## This PR fixes...

The lack of dictionary definition and perspective for "React"

## What I did...

- Add dictionary definition for React


## How to test...

_In a list format, tell us how to test this PR._
Ex:

1. Navigate to /dictionary
1. Search "React"
1. See if the definition and perspective show up under the term "React"
2. Check grammar and typos

## I learned...

I had lots of fun!
