### PR TITLE
Add dictionary definition for "GDPR"

### DIFF
--- a/src/assets/content/dictionary/general-data-protection-regulation-gdpr.md
+++ b/src/assets/content/dictionary/general-data-protection-regulation-gdpr.md
@@ -1,6 +1,11 @@
 ---
-title: General Data Protection Regulation (GDPR)
-definition: ''
-perspectives: []
+title: General Data Protection Regulation(GDPR)
+definition: 'General Data Protection Regulation(GDPR) is a regulation on the protection of natural persons in relation to the processing and free movement of personal data. It is a regulation based on EU law governing data protection and privacy in the European Union and the European Economic Area (EEA).
+ Its goal is to give EU citizens control over their personal data by holding companies accountable for the way they treat their data. The regulation applies regardless of where the website is hosted. In order that EU citizens are protected, all websites are to comply with the regulation'
+sources:
+- sourceurl:https://en.wikipedia.org/wiki/General_Data_Protection_Regulation
+perspectives:
+- meaning: developing software that is in compliance with the regulation and using technical and organizational measures in handling data appropriately
+  role: software developer
 
 ---

--- a/src/assets/content/dictionary/general-data-protection-regulation-gdpr.md
+++ b/src/assets/content/dictionary/general-data-protection-regulation-gdpr.md
@@ -1,7 +1,7 @@
 ---
 title: General Data Protection Regulation(GDPR)
 definition: 'General Data Protection Regulation(GDPR) is a regulation on the protection of natural persons in relation to the processing and free movement of personal data. It is a regulation based on EU law governing data protection and privacy in the European Union and the European Economic Area (EEA).
- Its goal is to give EU citizens control over their personal data by holding companies accountable for the way they treat their data. The regulation applies regardless of where the website is hosted. In order that EU citizens are protected, all websites are to comply with the regulation'
+ Its goal is to give EU citizens control over their personal data by holding companies accountable for the way they treat their data. The regulation applies regardless of where the website is hosted. In order that EU citizens are protected, all websites are to comply with the regulation.'
 sources:
 - sourceurl:https://en.wikipedia.org/wiki/General_Data_Protection_Regulation
 perspectives:


### PR DESCRIPTION
GDPR means General Data Protection Regulation

## This PR fixes...

The lack of a dictionary definition for "General Data Protection Regulation (GDPR)"

## What I did...

_Remove the example below. Then, list out the work you have done, in bullet form._
Ex:

- Add dictionary definition for GDPR 
- Add developer perspective for GDPR

## How to test...

_In a list format, tell us how to test this PR._
Ex:

1. Navigate to Dictionary
1. Search "General Data Protection Regulation (GDPR)"
1. See if the definition and perspective show up under the term "General Data Protection Regulation"
2. Check grammar and typo

## I learned...

I had fun!
