### PR TITLE
add dictionary definition for "blog"

### DIFF
--- a/src/assets/content/dictionary/blog.md
+++ b/src/assets/content/dictionary/blog.md
@@ -1,6 +1,12 @@
 ---
 title: blog
-definition: ''
-perspectives: []
+definition: a website that compiles a writer's or group of writers' personal experiences, observations, thoughts into text articles, often these posts have images or links to other websites.
+
+sources:
+- sourceurl: https://www.dictionary.com/browse/blog
+perspectives: 
+- meaning: "blog" can refer to the entire website OR just a single post within that website.
+  role: writer
+
 
 ---


### PR DESCRIPTION
## This PR fixes...

the lack of dictionary definition and perspective for "blog"

## What I did...

- add dictionary definition for "blog"
- add writer perspective for "blog"

## How to test...


1. Navigate to /dictionary
2. Search "blog"
3. See if the definition and perspective show up under term "blog"
4. Check grammar and typos

## I learned...

how to do my second pull request!