### PR TITLE
Add Definition of DevOps

### DIFF
--- a/src/assets/content/dictionary/devops.md
+++ b/src/assets/content/dictionary/devops.md
@@ -1,6 +1,9 @@
 ---
 title: DevOps
-definition: ''
-perspectives: []
-
+definition: DevOps is the combination of cultural philosophies, practices, and tools that increases an organization’s ability to deliver applications and services at high velocity: evolving and improving products at a faster pace than organizations using traditional software development and infrastructure management processes. 
+sources:
+- sourceurl: https://aws.amazon.com/devops/what-is-devops/
+perspectives:
+- meaning: a set of operations and practices aimed towards helping teams to effectively develop, deliver and operate software.
+  role: Software Developer
 ---

--- a/src/assets/content/dictionary/devops.md
+++ b/src/assets/content/dictionary/devops.md
@@ -1,9 +1,9 @@
 ---
 title: DevOps
-definition: DevOps is the combination of cultural philosophies, practices, and tools that increases an organization’s ability to deliver applications and services at high velocity: evolving and improving products at a faster pace than organizations using traditional software development and infrastructure management processes. 
+definition: "DevOps is the combination of cultural philosophies, practices, and tools that increases an organization’s ability to deliver applications and services at high velocity: evolving and improving products at a faster pace than organizations using traditional software development and infrastructure management processes." 
 sources:
 - sourceurl: https://aws.amazon.com/devops/what-is-devops/
 perspectives:
-- meaning: a set of operations and practices aimed towards helping teams to effectively develop, deliver and operate software.
-  role: Software Developer
+- meaning: a set of operations and practices aimed towards helping software development teams to effectively develop, deliver and operate software
+  role: software developer
 ---


### PR DESCRIPTION
## This PR fixes...

The lack of definition and perspective for DevOps

## What I did...

- Add dictionary definition for DevOps
- Add software developer perspective for DevOps

## How to test...

1. Navigate to /dictionary
1. Search 'DevOps'
1. See if the definition and perspective show up under  the term 'DevOps'
2. Check grammar and typos

## I learned...

nothing new really.
