### PR TITLE
Add definition and perspective for 'go live'

### DIFF
--- a/src/assets/content/dictionary/go-live.md
+++ b/src/assets/content/dictionary/go-live.md
@@ -1,9 +1,9 @@
 ---
 title: go live
-definition: Go live means to begin operating or to become available for use
+definition: Go live means to begin operating or to become available for use.
 sources:
 - sourceurl: https://www.merriam-webster.com/dictionary/go%20live
 perspectives:
-- meaning: when a product/platform is now accessible to the general public or the targetted users
+- meaning: when a product/platform is now accessible to the general public or the targeted users
   role: software developer
 ---

--- a/src/assets/content/dictionary/go-live.md
+++ b/src/assets/content/dictionary/go-live.md
@@ -1,6 +1,9 @@
 ---
 title: go live
-definition: ''
-perspectives: []
-
+definition: to begin operating or to become available for use
+sources:
+- sourceurl: https://www.merriam-webster.com/dictionary/go%20live
+perspectives:
+- meaning: a software product has gone live when it is now accessible to the general public or the targetted users.
+  role: Software developer
 ---

--- a/src/assets/content/dictionary/go-live.md
+++ b/src/assets/content/dictionary/go-live.md
@@ -1,9 +1,9 @@
 ---
 title: go live
-definition: to begin operating or to become available for use
+definition: Go live means to begin operating or to become available for use
 sources:
 - sourceurl: https://www.merriam-webster.com/dictionary/go%20live
 perspectives:
-- meaning: a software product has gone live when it is now accessible to the general public or the targetted users.
-  role: Software developer
+- meaning: when a product/platform is now accessible to the general public or the targetted users
+  role: software developer
 ---


### PR DESCRIPTION
## This PR fixes...

The lack of definition and perspective for 'go live'

## What I did...

- Add dictionary definition for 'go live'
- Add software developer perspective for 'go live'

## How to test...

1. Navigate to /dictionary
1. Search 'go live'
1. See if the definition and perspective show up under  the term 'go live'
2. Check grammar and typos

## I learned...

