### PR TITLE
Add definition and perspective for 'ideation'

### DIFF
--- a/src/assets/content/dictionary/ideation.md
+++ b/src/assets/content/dictionary/ideation.md
@@ -1,10 +1,10 @@
 ---
 title: ideation
-definition: the capacity for or the act of forming or entertaining ideas
+definition: Ideation is the capacity for or the act of forming or entertaining ideas
 sources:
 - sourceurl: https://www.merriam-webster.com/dictionary/ideation
 perspectives:
-- meaning: a stage in product design thinking process when team members brainstorms and explores solutions to the problem identified. it is a stage when ideas are generated and evaluated.
-  role: Product designer
+- meaning: a stage in product design thinking process when team members brainstorms and explores solutions to the problem identified. it is a stage when ideas are generated and evaluated
+  role: product designer
 
 ---

--- a/src/assets/content/dictionary/ideation.md
+++ b/src/assets/content/dictionary/ideation.md
@@ -1,6 +1,10 @@
 ---
 title: ideation
-definition: ''
-perspectives: []
+definition: the capacity for or the act of forming or entertaining ideas
+sources:
+- sourceurl: https://www.merriam-webster.com/dictionary/ideation
+perspectives:
+- meaning: a stage in design thinking process when team members brainstorms and explores solutions to the problem identified. it is a stage when ideas are generated and evaluated.
+  role: Software developer
 
 ---

--- a/src/assets/content/dictionary/ideation.md
+++ b/src/assets/content/dictionary/ideation.md
@@ -4,7 +4,7 @@ definition: the capacity for or the act of forming or entertaining ideas
 sources:
 - sourceurl: https://www.merriam-webster.com/dictionary/ideation
 perspectives:
-- meaning: a stage in design thinking process when team members brainstorms and explores solutions to the problem identified. it is a stage when ideas are generated and evaluated.
-  role: Software developer
+- meaning: a stage in product design thinking process when team members brainstorms and explores solutions to the problem identified. it is a stage when ideas are generated and evaluated.
+  role: Product designer
 
 ---

--- a/src/assets/content/dictionary/ideation.md
+++ b/src/assets/content/dictionary/ideation.md
@@ -1,10 +1,10 @@
 ---
 title: ideation
-definition: Ideation is the capacity for or the act of forming or entertaining ideas
+definition: Ideation is the capacity for or the act of forming or entertaining ideas.
 sources:
 - sourceurl: https://www.merriam-webster.com/dictionary/ideation
 perspectives:
-- meaning: a stage in product design thinking process when team members brainstorms and explores solutions to the problem identified. it is a stage when ideas are generated and evaluated
+- meaning: a stage in product design thinking process when team members brainstorm and explore solutions to the problem identified. It is a stage when ideas are generated and evaluated
   role: product designer
 
 ---


### PR DESCRIPTION
## This PR fixes...

The lack of definition and perspective for 'ideation'

## What I did...

- Add dictionary definition for 'ideation'
- Add product designer perspective for 'ideation'

## How to test...

1. Navigate to /dictionary
1. Search 'ideation'
1. See if the definition and perspective show up under  the term 'ideation'
2. Check grammar and typos

## I learned...

that ideation goes beyond product design process