### PR TITLE
Add definition and perspective for 'KPI'

### DIFF
--- a/src/assets/content/dictionary/kpi.md
+++ b/src/assets/content/dictionary/kpi.md
@@ -1,7 +1,10 @@
 ---
 title: KPI
-definition: ''
-sources: []
-perspectives: []
+definition: Key Performance Indicators (KPIs) is a critical (key) indicator of progress toward an intended result. A KPI provides a focus for strategic and operational improvement, create an analytical basis for decision making and help focus attention on what matters most.
+sources:
+- sourceurl: https://kpi.org/KPI-Basics
+perspectives:
+- meaning: is a metric or indicator to measure the work done by software teams in order to remain accountable to set objectives. Eg lines of code, bugs, task completion dealines.
+  role: Software developer
 
 ---

--- a/src/assets/content/dictionary/kpi.md
+++ b/src/assets/content/dictionary/kpi.md
@@ -4,7 +4,7 @@ definition: Key Performance Indicators (KPIs) is a critical (key) indicator of p
 sources:
 - sourceurl: https://kpi.org/KPI-Basics
 perspectives:
-- meaning: is a metric or indicator to measure the work done by software teams in order to remain accountable to set objectives. Eg lines of code, bugs, task completion dealines.
-  role: Software developer
+- meaning: a metric or indicator to measure the work done by software teams in order to remain accountable to set objectives. Eg lines of code, bugs, task completion dealines
+  role: software developer
 
 ---

--- a/src/assets/content/dictionary/kpi.md
+++ b/src/assets/content/dictionary/kpi.md
@@ -4,7 +4,7 @@ definition: Key Performance Indicators (KPIs) is a critical (key) indicator of p
 sources:
 - sourceurl: https://kpi.org/KPI-Basics
 perspectives:
-- meaning: a metric or indicator to measure the work done by software teams in order to remain accountable to set objectives. Eg lines of code, bugs, task completion dealines
+- meaning: a way to measure the work I have done in order to remain accountable to set objectives
   role: software developer
 
 ---


### PR DESCRIPTION
## This PR fixes...

The lack of definition and perspective for 'KPI'

## What I did...

- Add dictionary definition for 'KPI'
- Add Software developer perspective for 'KPI'

## How to test...

1. Navigate to /dictionary
1. Search 'KPI'
1. See if the definition and perspective show up under  the term 'KPI'
2. Check grammar and typos

## I learned...

That KPI is more of a business term other than a software term