### PR TITLE
added definition of callback hell

### DIFF
--- a/src/assets/content/dictionary/callback-hell.md
+++ b/src/assets/content/dictionary/callback-hell.md
@@ -1,6 +1,6 @@
 ---
 title: callback hell
-definition: ''
+definition: is a term used in programming to describe a situation where multiple nested callback functions in asynchronous code become hard to read, understand, and maintain. This occurs when asynchronous operations are dependent on the results of previous asynchronous operations, leading to deeply nested callback functions, which can make the code difficult to follow and prone to errors.
 perspectives: []
 
 ---

--- a/src/assets/content/dictionary/callback-hell.md
+++ b/src/assets/content/dictionary/callback-hell.md
@@ -1,6 +1,6 @@
 ---
 title: callback hell
-definition: is a term used in programming to describe a situation where multiple nested callback functions in asynchronous code become hard to read, understand, and maintain. This occurs when asynchronous operations are dependent on the results of previous asynchronous operations, leading to deeply nested callback functions, which can make the code difficult to follow and prone to errors.
+definition: A term used in programming to describe a situation where multiple nested callback functions in asynchronous code become hard to read, understand, and maintain. This occurs when asynchronous operations are dependent on the results of previous asynchronous operations, leading to deeply nested callback functions, which can make the code difficult to follow and prone to errors.
 perspectives: []
 
 ---


### PR DESCRIPTION
## This PR fixes...

This PR adds a definition for "callback hell" to the dictionary.

## What I did...

I added a definition for "callback hell" to the Dictionary. 

## How to test...

1. Navigate to https://cherryon.tech/dictionary/
2. Search the "callback hell" term.
3. Read the definition.

## I learned...
I learned that the alternative name for Callback Hell is the **Pyramid of Doom**, and I think I like this term better 😆 
