### PR TITLE
Added definition of Syntactically Awesome Style Sheets (SASS)

### DIFF
--- a/src/assets/content/dictionary/syntactically-awesome-style-sheets-sass.md
+++ b/src/assets/content/dictionary/syntactically-awesome-style-sheets-sass.md
@@ -1,6 +1,7 @@
 ---
 title: Syntactically Awesome Style Sheets (SASS)
-definition: ''
+definition: 'Sass is a stylesheet language that’s compiled to CSS. It allows you to use variables, nested rules, mixins, functions, and more, all with a fully CSS-compatible syntax. Sass helps keep large stylesheets well-organized and makes it easy to share design within and across projects.'
+sources:
+- sourceurl: https://sass-lang.com/documentation/
 perspectives: []
-
 ---


### PR DESCRIPTION
## This PR fixes...

This PR fixes the missing "Syntactically Awesome Style Sheets (SASS)" definition in the tech dictionary.

## What I did...

- Added the definiton of "Syntactically Awesome Style Sheets (SASS)"
- Added a source url for the definition

## How to test...

1. Go to the Netlify deploy preview page: https://deploy-preview-221--cherryontech.netlify.app/
2. Search for "Syntactically Awesome Style Sheets (SASS)" in the dictionary.
3. Verify that the definition of "Syntactically Awesome Style Sheets (SASS)" is displayed correctly.

## I learned...

I gained a deeper understanding of the term "SASS" and its significance in web development.

