### PR TITLE
update tech dictionary with commit history definition

### DIFF
--- a/src/assets/content/dictionary/commit-history.md
+++ b/src/assets/content/dictionary/commit-history.md
@@ -1,6 +1,6 @@
 ---
 title: commit history
-definition: ''
+definition: A way to view all of the commits (changes or updates) on a given branch.
 perspectives: []
 
 ---


### PR DESCRIPTION
## This PR fixes...

- an empty definition for commit history in the tech dictionary

## What I did...

- Update the tech dictionary page with the definition of commit history


## How to test...

1. Navigate to- navigate to https://cherryon.tech/dictionary/commit-history/
2. Review the definition & formatting for commit history

