### PR TITLE
fix: Include dictionary suggestion for bug reports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ This is an open source website, currently licensed under the MIT license. While 
 
 We always welcome you to [submit a bug report](https://github.com/cherryontech/website/issues/new?assignees=&labels=bug&template=bug_report.md&title=) if you see something wrong or confusing on the website.
 
+One especially helpful way to contribute to bug reports is to check for broken links in the [tech dictionary](https://cherryon.tech/dictionary). Bonus points for making a pull request to fix them (for more information on how to do that, read on to the next section of this file)!
+
 ## Contribute to our Tech Dictionary
 
 We also welcome contributions to our [tech dictionary](https://cherryon.tech/dictionary).


### PR DESCRIPTION
## This PR fixes...

This PR fixes the contributing document, which didn't tell users about an important way to make contributions to the repo.

## What I did...

- Added a suggestion to users about submitting bug reports for any potentially broken links in the tech dictionary.

## How to test...

1. Navigate to `CONTRIBUTING.md`
2. Read the "Contribute to bug reports" section
- Expect to see the suggestion text about making bug reports for broken links.

## I learned...

_Did you run into any interesting issues while making this PR? If you learned anything you would like to share, we'd love to know! Even if it is a fun fact or GIF!_
