### PR TITLE
fix[dictionary]: Move the definition from the meaning area to definition

### DIFF
--- a/src/assets/content/dictionary/adaptable.md
+++ b/src/assets/content/dictionary/adaptable.md
@@ -4,6 +4,6 @@ definition: 'The ability for a system to be personalized based on user input. Ad
 sources: 
 - sourceurl: https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=c942f84f37c0b2b548e5e189c267e066701fc285
 perspectives:
-- meaning: a system that can be personalized, with user input. Unlike with solely-adaptive systems, the user is able to make changes to the system.
+- meaning: a system that can be personalized, with user input. Unlike with solely-adaptive systems, the user is able to make changes to the system
   role: user interface designer
 ---

--- a/src/assets/content/dictionary/adaptable.md
+++ b/src/assets/content/dictionary/adaptable.md
@@ -1,9 +1,9 @@
 ---
 title: Adaptable
-definition: ''
+definition: 'The ability for a system to be personalized based on user input. Adaptability is one of two types of personalization on the spectrum of adaptation, along with adaptivity.'
 sources: 
 - sourceurl: https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=c942f84f37c0b2b548e5e189c267e066701fc285
 perspectives:
-- meaning: a system can be personalized, with user input. Unlike with solely-adaptive systems, the user is able to make changes to the system. Adaptability is one of two types of personalization on the spectrum of adaptation, along with adaptivity
+- meaning: a system that can be personalized, with user input. Unlike with solely-adaptive systems, the user is able to make changes to the system.
   role: user interface designer
 ---


### PR DESCRIPTION
## This PR fixes...

This PR fixes the definition for adaptable. There was no definition, but there was something like it in the perspectives section.

## What I did...

- Added the definition for adaptable
- Checked that the link still works
- Adjusted the perspectives so they're less definitioney 😛 

## How to test...

1. Navigate to the `/dictionary` route of the preview URL
2. Search for the word "adaptable"
- Expect the definition and perspectives to be formatted correctly
- Expect to see the updated text for both the definition and the perspective

## I learned...

- I learned that our Netlify deploys are still working 😆 
