### PR TITLE
feat: create a definition for SDLC in dictionary

### DIFF
--- a/src/assets/content/dictionary/sdlc.md
+++ b/src/assets/content/dictionary/sdlc.md
@@ -1,5 +1,5 @@
 title: SDLC
 definition: 'Short term for Software Development Life Cycle which  is the cost-effective and time-efficient process that development teams use to design and build high-quality software.'
 source:https://aws.amazon.com/what-is/sdlc/
-perspectives: []
+perspectives: [All about structure and efficiency in creating software, developers often circle back to earlier phases based on feedback and new requirements, making it a dynamic and evolving journey.]
 role: Developers

--- a/src/assets/content/dictionary/sdlc.md
+++ b/src/assets/content/dictionary/sdlc.md
@@ -1,0 +1,5 @@
+title: SDLC
+definition: 'Short term for Software Development Life Cycle which  is the cost-effective and time-efficient process that development teams use to design and build high-quality software.'
+source:https://aws.amazon.com/what-is/sdlc/
+perspectives: []
+role: Developers

--- a/src/assets/content/dictionary/sdlc.md
+++ b/src/assets/content/dictionary/sdlc.md
@@ -3,6 +3,6 @@ title: SDLC
 definition: 'Short term for Software Development Life Cycle which  is the cost-effective and time-efficient process that development teams use to design and build high-quality software.'
 source: https://aws.amazon.com/what-is/sdlc/
 perspectives: 
-- meaning: structure and efficiency in creating software, developers often circle back to earlier phases based on feedback and new requirements, making it a dynamic and evolving journey.
-role: developer
+- meaning: structure and efficiency in creating software, developers often circle back to earlier phases based on feedback and new requirements, making it a dynamic and evolving journey
+  role: developer
 ---

--- a/src/assets/content/dictionary/sdlc.md
+++ b/src/assets/content/dictionary/sdlc.md
@@ -1,7 +1,7 @@
 ---
 title: SDLC
 definition: 'Short term for Software Development Life Cycle which  is the cost-effective and time-efficient process that development teams use to design and build high-quality software.'
-source: [https://www.who.int/news-room/fact-sheets/detail/assistive-technology](https://aws.amazon.com/what-is/sdlc/)
+source: https://aws.amazon.com/what-is/sdlc/
 perspectives: [All about structure and efficiency in creating software, developers often circle back to earlier phases based on feedback and new requirements, making it a dynamic and evolving journey.]
 role: Developers
 ---

--- a/src/assets/content/dictionary/sdlc.md
+++ b/src/assets/content/dictionary/sdlc.md
@@ -2,6 +2,6 @@
 title: SDLC
 definition: 'Short term for Software Development Life Cycle which  is the cost-effective and time-efficient process that development teams use to design and build high-quality software.'
 source: https://aws.amazon.com/what-is/sdlc/
-perspectives: [All about structure and efficiency in creating software, developers often circle back to earlier phases based on feedback and new requirements, making it a dynamic and evolving journey.]
-role: Developers
+perspectives: structure and efficiency in creating software, developers often circle back to earlier phases based on feedback and new requirements, making it a dynamic and evolving journey.
+role: developer
 ---

--- a/src/assets/content/dictionary/sdlc.md
+++ b/src/assets/content/dictionary/sdlc.md
@@ -2,6 +2,7 @@
 title: SDLC
 definition: 'Short term for Software Development Life Cycle which  is the cost-effective and time-efficient process that development teams use to design and build high-quality software.'
 source: https://aws.amazon.com/what-is/sdlc/
-perspectives: structure and efficiency in creating software, developers often circle back to earlier phases based on feedback and new requirements, making it a dynamic and evolving journey.
+perspectives: 
+- meaning: structure and efficiency in creating software, developers often circle back to earlier phases based on feedback and new requirements, making it a dynamic and evolving journey.
 role: developer
 ---

--- a/src/assets/content/dictionary/sdlc.md
+++ b/src/assets/content/dictionary/sdlc.md
@@ -1,8 +1,8 @@
 ---
 title: SDLC
-definition: 'Short term for Software Development Life Cycle which  is the cost-effective and time-efficient process that development teams use to design and build high-quality software.'
+definition: 'SDLC is an acronym for Software Development Life Cycle. SDLC is a the cost-effective and time-efficient process that development teams use to design and build high-quality software.'
 source: https://aws.amazon.com/what-is/sdlc/
 perspectives: 
-- meaning: structure and efficiency in creating software, developers often circle back to earlier phases based on feedback and new requirements, making it a dynamic and evolving journey
+- meaning: a process I can use to help increase structure and efficiency when creating software. In SDLC, developers often circle back to earlier phases based on feedback and new requirements, making software creation a dynamic and evolving journey
   role: developer
 ---

--- a/src/assets/content/dictionary/sdlc.md
+++ b/src/assets/content/dictionary/sdlc.md
@@ -1,5 +1,7 @@
+---
 title: SDLC
 definition: 'Short term for Software Development Life Cycle which  is the cost-effective and time-efficient process that development teams use to design and build high-quality software.'
-source:https://aws.amazon.com/what-is/sdlc/
+source: [https://www.who.int/news-room/fact-sheets/detail/assistive-technology](https://aws.amazon.com/what-is/sdlc/)
 perspectives: [All about structure and efficiency in creating software, developers often circle back to earlier phases based on feedback and new requirements, making it a dynamic and evolving journey.]
 role: Developers
+---


### PR DESCRIPTION
## This PR fixes...

This PR adds a dictionary definition for SDLC.

## What I did...

- Added definition
- Added a source
- Added a role

## How to test...

1. Navigate to the `/dictionary` route of the preview URL
2. Search for the phrase "sdlc"
- Expect the definition and perspectives to be formatted correctly
- Expect to see correct, accurate text for both the definition and the perspective

## I learned...

I learned more about SDLC from the source I used.