### PR TITLE
Fix[dictionary]:remove duplicate entry css definition 

### DIFF
--- a/src/assets/content/dictionary/cascading-style-sheets-css.md
+++ b/src/assets/content/dictionary/cascading-style-sheets-css.md
@@ -1,6 +1,0 @@
----
-title: Cascading Style Sheets (CSS)
-definition: ''
-perspectives: []
-
----

--- a/src/assets/content/dictionary/css.md
+++ b/src/assets/content/dictionary/css.md
@@ -1,5 +1,5 @@
 ---
-title: CSS
+title: Cascading Style Sheets (CSS)
 definition: 'A computer language used to define the presentation of a document written in HTML or XML. This includes elements like web pages, mobile apps, and email. CSS controls the layout, colors, fonts, spacing, animations, and other visual aspects, separating content from its presentation.'
 sources:
 - sourceurl: https://developer.mozilla.org/en-US/docs/Web/CSS


### PR DESCRIPTION
## This PR fixes...

_Remove the example below. Then, add the related issue after the hash. Lastly, tell us what problems this PR is meant to solve._
Ex: This PR fixes #999. We didn't have a unicorn, so we went to the unicorn store and got one.

## What I did...
- Removed the duplicate css definition 
- update the title for other css definition 

## How to test...

1. Navigate to the /dictionary route of the preview URL
 2. Search for the phrase "css" technology"

. Expect the title to be formatted correctly
. Expect to see correct, accurate text for both the title & definition 
3. The duplicate css to be removed 

## I learned...
I learned how to create a branch from a branch . 