### PR TITLE
feat: Add definition for bitmap

### DIFF
--- a/src/assets/content/dictionary/bitmap.md
+++ b/src/assets/content/dictionary/bitmap.md
@@ -1,6 +1,7 @@
 ---
 title: bitmap
-definition: ''
-perspectives: []
+definition: A bitmap is a kind of image, formed from rows of pixels, each of which may have a different color.
+sources:
+- sourceurl: https://en.wikipedia.org/wiki/Bitmap
 
 ---


### PR DESCRIPTION
## This PR fixes...

The dictionary had a page for the term "bitmap," but no definition. This PR adds a definition for the term "bitmap."

## What I did...

- added a definition for the term "bitmap"

## How to test...

1. Navigate to the `/dictionary` route of the preview URL
2. Search for the phrase "bitmap"
- Expect the definition to be formatted correctly
- Expect to see correct, accurate text for the definition

## I learned...

